### PR TITLE
Google Chrome/Node JS Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+REPORTER=Spec
 VENDOR_FILE=build/ical.js
 LIB=lib/ical
 VENDOR_FILE_LIST= $(LIB)/helpers.js \
@@ -65,8 +66,18 @@ test-agent-config:
 	@rm -f /tmp/test-agent-config
 
 .PHONY: test
-test:
-	./node_modules/test-agent/bin/js-test-agent test
+test: test-browser test-node
+
+.PHONY: test-node
+test-node:
+	./node_modules/mocha/bin/mocha --ui tdd --reporter $(REPORTER) \
+		test/mocha/helper.js \
+		test/mocha/*_test.js \
+		test/mocha/acceptance/*_test.js
+
+.PHONY: test-browser
+test-browser:
+	./node_modules/test-agent/bin/js-test-agent test --reporter $(REPORTER)
 
 .PHONY: test-server
 test-server:

--- a/build/ical.js
+++ b/build/ical.js
@@ -2900,7 +2900,9 @@ var ICAL = ICAL || {};
 
       if (this.rule.freq == "WEEKLY") {
         if ("BYDAY" in parts) {
-          var [pos, rule_dow] = this.rule_day_of_week(parts.BYDAY[0]);
+          var parts = this.this.rule_day_of_week(parts.BYDAY[0]);
+          var pos = parts[0];
+          var rule_dow = parts[1];
           var dow = rule_dow - this.last.day_of_week();
           if ((this.last.day_of_week() < rule_dow && dow >= 0) || dow < 0) {
             // Initial time is after first day of BYDAY data
@@ -2930,7 +2932,9 @@ var ICAL = ICAL || {};
 
       if (this.rule.freq == "MONTHLY" && this.has_by_data("BYDAY")) {
         var coded_day = this.by_data.BYDAY[this.by_indices.BYDAY];
-        var [pos, dow] = this.rule_day_of_week(coded_day);
+        var parts = this.rule_day_of_week(coded_day);
+        var pos = parts[0];
+        var dow = parts[1];
 
         var days_in_month = ICAL.icaltime.days_in_month(this.last.month, this.last.year);
         var poscount = 0;
@@ -3124,7 +3128,9 @@ var ICAL = ICAL || {};
         for (day = last.day + 1; notFound && day <= days_in_month; day++) {
           for (var dayIdx = 0; dayIdx < this.by_data.BYDAY.length; dayIdx++) {
             for (var mdIdx = 0; mdIdx < this.by_data.BYMONTHDAY.length; mdIdx++) {
-              var [pos, dow] = this.rule_day_of_week(this.by_data.BYDAY[dayIdx]);
+              var parts = this.rule_day_of_week(this.by_data.BYDAY[dayIdx]);
+              var pos = parts[0];
+              var dow = parts[1];
               var mday = this.by_data.BYMONTHDAY[mdIdx];
 
               this.last.day = day;
@@ -3242,7 +3248,9 @@ var ICAL = ICAL || {};
         }
 
         var coded_day = this.by_data.BYDAY[this.by_indices.BYDAY];
-        var [, dow] = this.rule_day_of_week(coded_day);
+        var parts = this.rule_day_of_week(coded_day);
+        var dow = parts[1];
+
         dow -= this.rule.wkst;
         if (dow < 0) {
           dow += 7;
@@ -3528,7 +3536,9 @@ var ICAL = ICAL || {};
           } else {
             for (var daycodedkey in this.by_data.BYDAY) {
               var coded_day = this.by_data.BYDAY[daycodedkey];
-              var [dow, pos] = this.rule_day_of_week(coded_day);
+              var parts = this.rule_day_of_week(coded_day);
+              var dow = parts[0];
+              var pos = parts[1];
 
               var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
               var last_matching_day = days_in_month - ((last_dow + 7 - dow) % 7);
@@ -3624,7 +3634,9 @@ var ICAL = ICAL || {};
 
       for (var daykey in this.by_data.BYDAY) {
         var day = this.by_data.BYDAY[daykey];
-        var [pos, dow] = this.rule_day_of_week(day);
+        var parts = this.rule_day_of_week(day);
+        var pos = parts[0];
+        var dow = parts[1];
 
         if (pos == 0) {
           var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
@@ -3661,7 +3673,9 @@ var ICAL = ICAL || {};
     is_day_in_byday: function is_day_in_byday(tt) {
       for (var daykey in this.by_data.BYDAY) {
         var day = this.by_data.BYDAY[daykey];
-        var [pos, dow] = this.rule_day_of_week(day);
+        var parts = this.rule_day_of_week(day);
+        var pos = parts[0];
+        var dow = parts[1];
         var this_dow = tt.day_of_week();
 
         if ((pos == 0 && dow == this_dow) ||
@@ -3681,8 +3695,8 @@ var ICAL = ICAL || {};
     sort_byday_rules: function icalrecur_sort_byday_rules(aRules, aWeekStart) {
       for (var i = 0; i < aRules.length; i++) {
         for (var j = 0; j < i; j++) {
-          var [, one] = this.rule_day_of_week(aRules[j]);
-          var [, two] = this.rule_day_of_week(aRules[i]);
+          var one = this.rule_day_of_week(aRules[j])[1];
+          var two = this.rule_day_of_week(aRules[i])[1];
           one -= aWeekStart;
           two -= aWeekStart;
           if (one < 0) one += 7;

--- a/lib/ical/component.js
+++ b/lib/ical/component.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icalcomponent = function icalcomponent(data, parent) {
     this.wrappedJSObject = this;
@@ -197,7 +197,7 @@ var ICAL = ICAL || {};
 
       ICAL.helpers.ensureKeyExists(this.properties, aProp.name, []);
       this.properties[aProp.name].push(aProp);
-      ICAL.helpers.dumpn("DATA IS: " + this.data.toSource());
+      ICAL.helpers.dumpn("DATA IS: " + this.data.toString());
       this.data.value.push(aProp);
       ICAL.helpers.dumpn("Adding property " + aProp);
     },

--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 
 /**
  * Design data used by the parser to decide if data is semantically correct

--- a/lib/ical/duration.js
+++ b/lib/ical/duration.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icalduration = function icalduration(data) {
     this.wrappedJSObject = this;

--- a/lib/ical/helpers.js
+++ b/lib/ical/helpers.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 
 /**
  * Helper functions used in various places within ical.js

--- a/lib/ical/ical.js
+++ b/lib/ical/ical.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 
 (function() {
   ICAL.foldLength = 75;

--- a/lib/ical/parser.js
+++ b/lib/ical/parser.js
@@ -9,7 +9,7 @@
 // TODO enforce uppercase when parsing
 // TODO optionally preserve value types that are default but explicitly set
 // TODO floating timezone
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   /* NOTE: I'm not sure this is the latest syntax...
 
@@ -210,10 +210,10 @@ var ICAL = ICAL || {};
       }
       break;
     default:
-      ICAL.helpers.dumpn("parse " + aLineData.toSource());
+      ICAL.helpers.dumpn("parse " + aLineData.toString());
       parser.detectParameterType(aLineData);
       parser.detectValueType(aLineData);
-      ICAL.helpers.dumpn("parse " + aLineData.toSource());
+      ICAL.helpers.dumpn("parse " + aLineData.toString());
       aState.currentData.value.push(aLineData);
       break;
     }
@@ -244,7 +244,7 @@ var ICAL = ICAL || {};
     }
 
     if ("parameters" in aLineData && "VALUE" in aLineData.parameters) {
-      ICAL.helpers.dumpn("VAAAA: " + aLineData.parameters.VALUE.toSource());
+      ICAL.helpers.dumpn("VAAAA: " + aLineData.parameters.VALUE.toString());
       valueType = aLineData.parameters.VALUE.value.toUpperCase();
     }
 
@@ -299,7 +299,7 @@ var ICAL = ICAL || {};
     // in the states) validators don't really need the whole linedata
 
     if (!aValue.match) {
-      ICAL.helpers.dumpn("MAAA: " + aValue + " ? " + aValue.toSource());
+      ICAL.helpers.dumpn("MAAA: " + aValue + " ? " + aValue.toString());
     }
 
     if (valueData.matches) {
@@ -354,7 +354,7 @@ var ICAL = ICAL || {};
   };
 
   parser.stringifyProperty = function stringifyProperty(aLineData) {
-    ICAL.helpers.dumpn("Stringify: " + aLineData.toSource());
+    ICAL.helpers.dumpn("Stringify: " + aLineData.toString());
     var str = aLineData.name;
     if (aLineData.parameters) {
       for (var key in aLineData.parameters) {
@@ -778,7 +778,7 @@ var ICAL = ICAL || {};
 
   parser.parseAlternative = function parseAlternative(aState /*, parserFunc, ... */) {
     var tokens = null;
-    var args = Array.slice(arguments);
+    var args = Array.prototype.slice.call(arguments);
     var parser;
     args.shift();
     var errors = [];

--- a/lib/ical/period.js
+++ b/lib/ical/period.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icalperiod = function icalperiod(aData) {
     this.wrappedJSObject = this;

--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icalproperty = function icalproperty(data, parent) {
     this.wrappedJSObject = this;
@@ -24,7 +24,7 @@ var ICAL = ICAL || {};
 
     fromData: function fromData(aData) {
       if (!aData.name) {
-        ICAL.helpers.dumpn("Missing name: " + aData.toSource());
+        ICAL.helpers.dumpn("Missing name: " + aData.toString());
       }
       this.name = aData.name;
       this.data = aData;

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -253,7 +253,9 @@ var ICAL = ICAL || {};
 
       if (this.rule.freq == "WEEKLY") {
         if ("BYDAY" in parts) {
-          var [pos, rule_dow] = this.rule_day_of_week(parts.BYDAY[0]);
+          var parts = this.this.rule_day_of_week(parts.BYDAY[0]);
+          var pos = parts[0];
+          var rule_dow = parts[1];
           var dow = rule_dow - this.last.day_of_week();
           if ((this.last.day_of_week() < rule_dow && dow >= 0) || dow < 0) {
             // Initial time is after first day of BYDAY data
@@ -283,7 +285,9 @@ var ICAL = ICAL || {};
 
       if (this.rule.freq == "MONTHLY" && this.has_by_data("BYDAY")) {
         var coded_day = this.by_data.BYDAY[this.by_indices.BYDAY];
-        var [pos, dow] = this.rule_day_of_week(coded_day);
+        var parts = this.rule_day_of_week(coded_day);
+        var pos = parts[0];
+        var dow = parts[1];
 
         var days_in_month = ICAL.icaltime.days_in_month(this.last.month, this.last.year);
         var poscount = 0;
@@ -477,7 +481,9 @@ var ICAL = ICAL || {};
         for (day = last.day + 1; notFound && day <= days_in_month; day++) {
           for (var dayIdx = 0; dayIdx < this.by_data.BYDAY.length; dayIdx++) {
             for (var mdIdx = 0; mdIdx < this.by_data.BYMONTHDAY.length; mdIdx++) {
-              var [pos, dow] = this.rule_day_of_week(this.by_data.BYDAY[dayIdx]);
+              var parts = this.rule_day_of_week(this.by_data.BYDAY[dayIdx]);
+              var pos = parts[0];
+              var dow = parts[1];
               var mday = this.by_data.BYMONTHDAY[mdIdx];
 
               this.last.day = day;
@@ -595,7 +601,9 @@ var ICAL = ICAL || {};
         }
 
         var coded_day = this.by_data.BYDAY[this.by_indices.BYDAY];
-        var [, dow] = this.rule_day_of_week(coded_day);
+        var parts = this.rule_day_of_week(coded_day);
+        var dow = parts[1];
+
         dow -= this.rule.wkst;
         if (dow < 0) {
           dow += 7;
@@ -881,7 +889,9 @@ var ICAL = ICAL || {};
           } else {
             for (var daycodedkey in this.by_data.BYDAY) {
               var coded_day = this.by_data.BYDAY[daycodedkey];
-              var [dow, pos] = this.rule_day_of_week(coded_day);
+              var parts = this.rule_day_of_week(coded_day);
+              var dow = parts[0];
+              var pos = parts[1];
 
               var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
               var last_matching_day = days_in_month - ((last_dow + 7 - dow) % 7);
@@ -977,7 +987,9 @@ var ICAL = ICAL || {};
 
       for (var daykey in this.by_data.BYDAY) {
         var day = this.by_data.BYDAY[daykey];
-        var [pos, dow] = this.rule_day_of_week(day);
+        var parts = this.rule_day_of_week(day);
+        var pos = parts[0];
+        var dow = parts[1];
 
         if (pos == 0) {
           var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
@@ -1014,7 +1026,9 @@ var ICAL = ICAL || {};
     is_day_in_byday: function is_day_in_byday(tt) {
       for (var daykey in this.by_data.BYDAY) {
         var day = this.by_data.BYDAY[daykey];
-        var [pos, dow] = this.rule_day_of_week(day);
+        var parts = this.rule_day_of_week(day);
+        var pos = parts[0];
+        var dow = parts[1];
         var this_dow = tt.day_of_week();
 
         if ((pos == 0 && dow == this_dow) ||
@@ -1034,8 +1048,8 @@ var ICAL = ICAL || {};
     sort_byday_rules: function icalrecur_sort_byday_rules(aRules, aWeekStart) {
       for (var i = 0; i < aRules.length; i++) {
         for (var j = 0; j < i; j++) {
-          var [, one] = this.rule_day_of_week(aRules[j]);
-          var [, two] = this.rule_day_of_week(aRules[i]);
+          var one = this.rule_day_of_week(aRules[j])[1];
+          var two = this.rule_day_of_week(aRules[i])[1];
           one -= aWeekStart;
           two -= aWeekStart;
           if (one < 0) one += 7;

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icalrecur = function icalrecur(data) {
     this.wrappedJSObject = this;
@@ -153,6 +153,8 @@ var ICAL = ICAL || {};
     fromIcalProperty: function fromIcalProperty(aProp) {
       var propval = aProp.getFirstValue();
       this.fromData(propval);
+      //TODO: we should not use eval anywhere and
+      // this only works in gecko (toSource)
       this.parts = eval(propval.parts.toSource());
       if (aProp.name == "EXRULE") {
         this.isNegative = true;
@@ -182,6 +184,8 @@ var ICAL = ICAL || {};
   function icalrecur_iterator(aRule, aStart) {
     this.rule = aRule;
     this.dtstart = aStart;
+    //TODO: we should not use eval anywhere and
+    // this only works in gecko (toSource)
     this.by_data = eval(aRule.parts.toSource());
     this.days = [];
     this.init();

--- a/lib/ical/serializer.js
+++ b/lib/ical/serializer.js
@@ -1,4 +1,4 @@
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 
 (function() {
   ICAL.serializer = {

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icaltime = function icaltime(data) {
     this.wrappedJSObject = this;

--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icaltimezone = function icaltimezone(data) {
     this.wrappedJSObject = this;
@@ -86,6 +86,8 @@ var ICAL = ICAL || {};
       var step = 1;
 
       for (;;) {
+        //TODO: we should not use eval anywhere and
+        // this only works in gecko (toSource)
         var change = eval(this.changes[change_num].toSource()); // TODO clone
         if (change.utc_offset < change.prev_utc_offset) {
           ICAL.helpers.dumpn("Adjusting " + change.utc_offset);
@@ -97,7 +99,7 @@ var ICAL = ICAL || {};
         }
 
         var cmp = ICAL.icaltimezone._compare_change_fn(tt_change, change);
-        ICAL.helpers.dumpn("Compare" + cmp + " / " + change.toSource());
+        ICAL.helpers.dumpn("Compare" + cmp + " / " + change.toString());
 
         if (cmp >= 0) {
           change_num_to_use = change_num;
@@ -124,6 +126,8 @@ var ICAL = ICAL || {};
       var utc_offset_change = zone_change.utc_offset - zone_change.prev_utc_offset;
 
       if (utc_offset_change < 0 && change_num_to_use > 0) {
+        //TODO: we should not use eval anywhere and
+        // this only works in gecko (toSource)
         var tmp_change = eval(zone_change.toSource()); // TODO copy
         ICAL.icaltimezone.adjust_change(tmp_change, 0, 0, 0,
                                         tmp_change.prev_utc_offset);

--- a/lib/ical/value.js
+++ b/lib/ical/value.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var ICAL = ICAL || {};
+(typeof(ICAL) === 'undefined')? ICAL = {} : '';
 (function() {
   ICAL.icalvalue = function icalvalue(aData, aParent, aType) {
     this.parent = aParent;

--- a/test/mocha/helper.js
+++ b/test/mocha/helper.js
@@ -1,5 +1,10 @@
 (function() {
-  window.navigator;
+
+  var isNode = typeof(window) === 'undefined';
+
+  if (!isNode) {
+    window.navigator;
+  }
 
   // lazy defined navigator causes global leak warnings...
 
@@ -46,7 +51,7 @@
     }
 
     if (typeof(window) === 'undefined') {
-      var lib = require(__dirname + '/../' + file);
+      var lib = require(__dirname + '/../../' + file);
       if (typeof(callback) !== 'undefined') {
         callback(lib);
       }
@@ -58,7 +63,7 @@
   //chai has no backtraces in ff
   //this patch will change the error
   //class used to provide real .stack.
-  function setupChai() {
+  function setupChai(chai) {
     function chaiAssert(expr, msg, negateMsg, expected, actual) {
       actual = actual || this.obj;
       var msg = (this.negate ? negateMsg : msg),
@@ -91,7 +96,7 @@
 
   testSupport.loadSample = function(file, cb) {
     if (testSupport.isNode) {
-      var root = __dirname + '/../samples/';
+      var root = __dirname + '/../../samples/';
       require('fs').readFile(root + file, 'utf8', function(err, contents) {
         cb(err, contents);
       });


### PR DESCRIPTION
- Add basic support for NodeJS
- Tests pass in Firefox/Chrome/NodeJS

We need to remove the use of toSource everywhere and ideally get rid of any eval's I will create a issue for that because of CSP/Usual reasons we should not use eval anywhere.

toSource seem to be used in both time.js and recur.js so those will break anything non-gecko.
