### PR TITLE
Remove eval and toSource usage

### DIFF
--- a/lib/ical/helpers.js
+++ b/lib/ical/helpers.js
@@ -53,6 +53,39 @@ ICAL.helpers = {
     return obj;
   },
 
+  isArray: function(o) {
+    return o && (o instanceof Array || typeof o == "array");
+  },
+
+  clone: function(aSrc, aDeep) {
+    if (!aSrc || typeof aSrc != "object") {
+      return aSrc;
+    } else if (aSrc instanceof Date) {
+      return new Date(aSrc.getTime());
+    } else if ("clone" in aSrc) {
+      return aSrc.clone();
+    } else if (ICAL.helpers.isArray(aSrc)) {
+      var result = [];
+      for (var i = 0; i < aSrc.length; i++) {
+        result.push(aDeep ? ICAL.helpers.clone(aSrc[i], true) : aSrc[i]);
+      }
+      return result;
+    } else {
+      var result = {};
+      for (var name in aSrc) {
+        if (aSrc.hasOwnProperty(name)) {
+          dump("Cloning " + name + "\n");
+          if (aDeep) {
+            result[name] = ICAL.helpers.clone(aSrc[name], true);
+          } else {
+            result[name] = aSrc[name];
+          }
+        }
+      }
+      return result;
+    }
+  },
+
   unfoldline: function unfoldline(aState) {
     // Section 3.1
     // if the line ends with a CRLF

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -153,9 +153,7 @@
     fromIcalProperty: function fromIcalProperty(aProp) {
       var propval = aProp.getFirstValue();
       this.fromData(propval);
-      //TODO: we should not use eval anywhere and
-      // this only works in gecko (toSource)
-      this.parts = eval(propval.parts.toSource());
+      this.parts = ICAL.helpers.clone(propval.parts, true);
       if (aProp.name == "EXRULE") {
         this.isNegative = true;
       } else if (aProp.name == "RRULE") {
@@ -184,9 +182,7 @@
   function icalrecur_iterator(aRule, aStart) {
     this.rule = aRule;
     this.dtstart = aStart;
-    //TODO: we should not use eval anywhere and
-    // this only works in gecko (toSource)
-    this.by_data = eval(aRule.parts.toSource());
+    this.by_data = ICAL.helpers.clone(aRule.parts, true);
     this.days = [];
     this.init();
   }

--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -45,10 +45,8 @@
       if (aData && "component" in aData) {
         if (typeof aData.component == "string") {
           this.component = this.componentFromString(aData.component);
-        } else if (aData.component.icalclass == "icalcomponent") {
-          this.component = aData.component.clone();
         } else {
-          this.component = eval(aData.component.toSource());
+          this.component = ICAL.helpers.clone(aData.component, true);
         }
       } else {
         this.component = null;
@@ -86,9 +84,7 @@
       var step = 1;
 
       for (;;) {
-        //TODO: we should not use eval anywhere and
-        // this only works in gecko (toSource)
-        var change = eval(this.changes[change_num].toSource()); // TODO clone
+        var change = ICAL.helpers.clone(this.changes[change_num], true);
         if (change.utc_offset < change.prev_utc_offset) {
           ICAL.helpers.dumpn("Adjusting " + change.utc_offset);
           ICAL.icaltimezone.adjust_change(change, 0, 0, 0, change.utc_offset);
@@ -126,9 +122,7 @@
       var utc_offset_change = zone_change.utc_offset - zone_change.prev_utc_offset;
 
       if (utc_offset_change < 0 && change_num_to_use > 0) {
-        //TODO: we should not use eval anywhere and
-        // this only works in gecko (toSource)
-        var tmp_change = eval(zone_change.toSource()); // TODO copy
+        var tmp_change = ICAL.helpers.clone(zone_change, true);
         ICAL.icaltimezone.adjust_change(tmp_change, 0, 0, 0,
                                         tmp_change.prev_utc_offset);
 


### PR DESCRIPTION
Ideally I can enable CSP in calendar app to improve security when I eventually want to enable HTML descriptions I have other blocking issues in calendar itself that prevents me from using the full advantages of CSP but this eval is a blocker long term.
