### PR TITLE
recur expansion now works with non recurring events

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -5135,7 +5135,7 @@ ICAL.RecurExpansion = (function() {
    *       with ICAL.Event which handles recurrence exceptions.
    *
    * Options:
-   *  - startDate: (ICAL.icaltime) start time of event (required)
+   *  - dtstart: (ICAL.icaltime) start time of event (required)
    *  - component: (ICAL.icalcomponent) component (required unless resuming)
    *
    * Examples:
@@ -5418,6 +5418,15 @@ ICAL.RecurExpansion = (function() {
       this.ruleIterators = [];
 
       this.last = this.dtstart.clone();
+
+      // to provide api consistency non-recurring
+      // events can also use the iterator though it will
+      // only return a single time.
+      if (!isRecurringComponent(component)) {
+        this.ruleDate = this.last.clone();
+        this.complete = true;
+        return;
+      }
 
       if (component.hasProperty('RRULE')) {
         var rules = component.getAllProperties('RRULE');

--- a/lib/ical/recur_expansion.js
+++ b/lib/ical/recur_expansion.js
@@ -29,7 +29,7 @@ ICAL.RecurExpansion = (function() {
    *       with ICAL.Event which handles recurrence exceptions.
    *
    * Options:
-   *  - startDate: (ICAL.icaltime) start time of event (required)
+   *  - dtstart: (ICAL.icaltime) start time of event (required)
    *  - component: (ICAL.icalcomponent) component (required unless resuming)
    *
    * Examples:
@@ -312,6 +312,15 @@ ICAL.RecurExpansion = (function() {
       this.ruleIterators = [];
 
       this.last = this.dtstart.clone();
+
+      // to provide api consistency non-recurring
+      // events can also use the iterator though it will
+      // only return a single time.
+      if (!isRecurringComponent(component)) {
+        this.ruleDate = this.last.clone();
+        this.complete = true;
+        return;
+      }
 
       if (component.hasProperty('RRULE')) {
         var rules = component.getAllProperties('RRULE');

--- a/test/mocha/recur_expansion_test.js
+++ b/test/mocha/recur_expansion_test.js
@@ -259,4 +259,32 @@ suite('recur_expansion', function() {
 
   });
 
+  suite('event without recurrences', function() {
+    createSubject('minimal.ics');
+
+    test('iterate', function() {
+      var dates = [];
+      var next;
+
+      var expected = primary.startDate.toJSDate();
+
+      while ((next = subject.next())) {
+        dates.push(next.toJSDate());
+      }
+
+      assert.deepEqual(dates[0], expected);
+      assert.length(dates, 1);
+      assert.isTrue(subject.complete);
+
+      // json check
+      subject = new ICAL.RecurExpansion(
+        subject.toJSON()
+      );
+
+      assert.isTrue(subject.complete, 'complete after json');
+      assert.ok(!subject.next(), 'next value');
+    });
+
+  });
+
 });


### PR DESCRIPTION
Simplifies some logic in gaia so everything can go through a Recur Expansion to find individual instances of an event. I think this is useful enough to be generic. Though strictly speaking for performance this can be avoided by checking if the event is recurring.
