### PR TITLE
Fix type detection for properties

### DIFF
--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -26,7 +26,7 @@ ICAL.Property = (function() {
     if (typeof(jCal) === 'string') {
       // because we a creating by name we need
       // to find the type when creating the property.
-      var name = jCal;
+      var name = jCal.toLowerCase();
 
       if (name in design.property) {
         var prop = design.property[name];

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -287,15 +287,31 @@ suite('Component', function() {
     assert.equal(lastProp.component, subject);
   });
 
-  test('#addPropertyWithValue', function() {
-    var subject = new ICAL.Component('vevent');
+  suite('#addPropertyWithValue', function() {
+    test('adding a text property', function() {
+      var subject = new ICAL.Component('vevent');
 
-    subject.addPropertyWithValue('description', 'value');
+      subject.addPropertyWithValue('description', 'value');
 
-    var all = subject.getAllProperties();
+      var all = subject.getAllProperties();
 
-    assert.equal(all[0].name, 'description');
-    assert.equal(all[0].getFirstValue(), 'value');
+      assert.equal(all[0].name, 'description');
+      assert.equal(all[0].type, 'text');
+      assert.equal(all[0].getFirstValue(), 'value');
+    });
+
+    test('adding a date-time property', function() {
+      var subject = new ICAL.Component('vevent');
+      var propval = ICAL.Time.fromString('2012-10-12T07:08:09');
+
+      subject.addPropertyWithValue('created', propval);
+
+      var all = subject.getAllProperties();
+
+      assert.equal(all[0].name, 'created');
+      assert.equal(all[0].type, 'date-time');
+      assert.equal(all[0].getFirstValue(), propval);
+    });
   });
 
   test('#updatePropertyWithValue', function() {


### PR DESCRIPTION
To reproduce, add a property using updatePropertyWithValue that is not a text type, i.e CREATED. Detection doesn't find the uppercase CREATED, makes it a text property, which is not expected by other parts of the code and causes trouble when serializing.
