### PR TITLE
Remove obsolete componentFromString method reference

### DIFF
--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -50,27 +50,39 @@
       this.changes = [];
 
       if (aData instanceof ICAL.Component) {
+        // Either a component is passed directly
         this.component = aData;
-        this.tzid = this.component.getFirstPropertyValue('tzid');
-        return null;
-      }
-
-      for (var key in OPTIONS) {
-        var prop = OPTIONS[key];
-        if (aData && prop in aData) {
-          this[prop] = aData[prop];
-        }
-      }
-
-      if (aData && "component" in aData) {
-        if (typeof aData.component == "string") {
-          this.component = this.componentFromString(aData.component);
-        } else {
-          this.component = aData.component;
-        }
       } else {
-        this.component = null;
+        // Otherwise the component may be in the data object
+        if (aData && "component" in aData) {
+          if (typeof aData.component == "string") {
+            // If a string was passed, parse it as a component
+            var icalendar = ICAL.parse(aData.component);
+            this.component = new ICAL.Component(icalendar[1]);
+          } else if (aData.component instanceof ICAL.Component) {
+            // If it was a component already, then just set it
+            this.component = aData.component;
+          } else {
+            // Otherwise just null out the component
+            this.component = null;
+          }
+        }
+
+        // Copy remaining passed properties
+        for (var key in OPTIONS) {
+          var prop = OPTIONS[key];
+          if (aData && prop in aData) {
+            this[prop] = aData[prop];
+          }
+        }
       }
+
+      // If we have a component but no TZID, attempt to get it from the
+      // component's properties.
+      if (this.component instanceof ICAL.Component && !this.tzid) {
+        this.tzid = this.component.getFirstPropertyValue('tzid');
+      }
+
       return this;
     },
 

--- a/test/timezone_test.js
+++ b/test/timezone_test.js
@@ -195,4 +195,24 @@ suite('timezone', function() {
       assert.equal(subject3.toString(), '2012-03-11T01:59:00');
     });
   });
+
+  timezoneTest('America/Los_Angeles', '#fromData string component', function() {
+    var subject = new ICAL.Timezone({
+      component: timezone.component.toString(),
+      tzid: 'Makebelieve/Different'
+    });
+
+    assert.equal(subject.expandedUntilYear, 0);
+    assert.equal(subject.tzid, 'Makebelieve/Different');
+    assert.equal(subject.component.getFirstPropertyValue('tzid'), 'America/Los_Angeles');
+  });
+
+  timezoneTest('America/Los_Angeles', '#fromData component in data', function() {
+    var subject = new ICAL.Timezone({
+      component: timezone.component,
+    });
+
+    assert.equal(subject.tzid, 'America/Los_Angeles');
+    assert.deepEqual(subject.component, timezone.component);
+  });
 });


### PR DESCRIPTION
This method is no longer used, replacing it with a different method to parse the component string.
