### PR TITLE
subtractDate incorrectly calculates date differences with different timezones.

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -2688,7 +2688,8 @@ ICAL.Binary = (function() {
 
       if (aData && "component" in aData) {
         if (typeof aData.component == "string") {
-          this.component = this.componentFromString(aData.component);
+          let icalendar = ICAL.parse(aData.component);
+          this.component = new ICAL.Component(icalendar[1]);
         } else {
           this.component = aData.component;
         }

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -420,13 +420,11 @@
      * @return {ICAL.Duration} difference in duration.
      */
     subtractDate: function icaltime_subtract(aDate) {
-      var unixTime = this.toUnixTime() + this.utcOffset();
-      var other = aDate.toUnixTime() + aDate.utcOffset();
-      var diff = (unixTime - other);
-
-      return ICAL.Duration.fromSeconds(
-        diff
-      );
+      // The unix time already has timezone offsets applied, we just need to
+      // compare them.
+      var unixTime = this.toUnixTime();
+      var other = aDate.toUnixTime();
+      return ICAL.Duration.fromSeconds(unixTime - other);
     },
 
     compare: function icaltime_compare(other) {

--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -64,7 +64,8 @@
 
       if (aData && "component" in aData) {
         if (typeof aData.component == "string") {
-          this.component = this.componentFromString(aData.component);
+          let icalendar = ICAL.parse(aData.component);
+          this.component = new ICAL.Component(icalendar[1]);
         } else {
           this.component = aData.component;
         }


### PR DESCRIPTION
`toUnixTime()` gets the unix time in UTC, but `subtractDate()` adds the utc offset again. Fix is quite easy, I'll upload a fix for this soon.
