### PR TITLE
subtractDate incorrectly calculates date differences with different timezones

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -3512,13 +3512,11 @@ ICAL.TimezoneService = (function() {
      * @return {ICAL.Duration} difference in duration.
      */
     subtractDate: function icaltime_subtract(aDate) {
-      var unixTime = this.toUnixTime() + this.utcOffset();
-      var other = aDate.toUnixTime() + aDate.utcOffset();
-      var diff = (unixTime - other);
-
-      return ICAL.Duration.fromSeconds(
-        diff
-      );
+      // The unix time already has timezone offsets applied, we just need to
+      // compare them.
+      var unixTime = this.toUnixTime();
+      var other = aDate.toUnixTime();
+      return ICAL.Duration.fromSeconds(unixTime - other);
     },
 
     compare: function icaltime_compare(other) {

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -420,13 +420,11 @@
      * @return {ICAL.Duration} difference in duration.
      */
     subtractDate: function icaltime_subtract(aDate) {
-      var unixTime = this.toUnixTime() + this.utcOffset();
-      var other = aDate.toUnixTime() + aDate.utcOffset();
-      var diff = (unixTime - other);
-
-      return ICAL.Duration.fromSeconds(
-        diff
-      );
+      // The unix time already has timezone offsets applied, we just need to
+      // compare them.
+      var unixTime = this.toUnixTime();
+      var other = aDate.toUnixTime();
+      return ICAL.Duration.fromSeconds(unixTime - other);
     },
 
     compare: function icaltime_compare(other) {

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -122,7 +122,7 @@ suite('icaltime', function() {
   suite('#subtractDate', function() {
     testSupport.useTimezones('America/Los_Angeles', 'America/New_York');
 
-    test('relative diff between two times', function() {
+    test('absolute diff between two times', function() {
       // 3 hours ahead of west
       var east = new ICAL.Time({
         year: 2012,
@@ -146,9 +146,62 @@ suite('icaltime', function() {
       var diff = west.subtractDate(east);
 
       assert.hasProperties(diff, {
-        hours: 2,
+        hours: 5,
         minutes: 30,
         isNegative: false
+      });
+    });
+
+    test('absolute diff in same timezone', function() {
+      var t1 = new ICAL.Time({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 21,
+        minute: 50,
+        timezone: 'America/Los_Angeles'
+      });
+      var t2 = new ICAL.Time({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 8,
+        minute: 30,
+        timezone: 'America/Los_Angeles'
+      });
+
+      var diff = t1.subtractDate(t2);
+
+      assert.hasProperties(diff, {
+        hours: 13,
+        minutes: 20,
+        isNegative: false
+      });
+    });
+    test('negative absolute difference', function() {
+      var t1 = new ICAL.Time({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 8,
+        minute: 30,
+        timezone: 'America/Los_Angeles'
+      });
+      var t2 = new ICAL.Time({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 21,
+        minute: 50,
+        timezone: 'America/Los_Angeles'
+      });
+
+      var diff = t1.subtractDate(t2);
+
+      assert.hasProperties(diff, {
+        hours: 13,
+        minutes: 20,
+        isNegative: true
       });
     });
   });


### PR DESCRIPTION
`toUnixTime()` gets the unix time in UTC, but `subtractDate()` adds the utc offset again. Correction for PR #67 
