### PR TITLE
Don't allow zero/negative INTERVAL, assume 1

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -4147,7 +4147,7 @@ ICAL.TimezoneService = (function() {
       if (this.count) {
         str += ";COUNT=" + this.count;
       }
-      if (this.interval != 1) {
+      if (this.interval > 1) {
         str += ";INTERVAL=" + this.interval;
       }
       for (var k in this.parts) {
@@ -4226,6 +4226,11 @@ ICAL.TimezoneService = (function() {
 
     INTERVAL: function(value, dict) {
       dict.interval = ICAL.helpers.strictParseInt(value);
+      if (dict.interval < 1) {
+        // 0 or negative values are not allowed, some engines seem to generate
+        // it though. Assume 1 instead.
+        dict.interval = 1;
+      }
     },
 
     UNTIL: function(value, dict) {

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -149,7 +149,7 @@
       if (this.count) {
         str += ";COUNT=" + this.count;
       }
-      if (this.interval != 1) {
+      if (this.interval > 1) {
         str += ";INTERVAL=" + this.interval;
       }
       for (var k in this.parts) {
@@ -228,6 +228,11 @@
 
     INTERVAL: function(value, dict) {
       dict.interval = ICAL.helpers.strictParseInt(value);
+      if (dict.interval < 1) {
+        // 0 or negative values are not allowed, some engines seem to generate
+        // it though. Assume 1 instead.
+        dict.interval = 1;
+      }
     },
 
     UNTIL: function(value, dict) {

--- a/test/recur_test.js
+++ b/test/recur_test.js
@@ -330,6 +330,14 @@ suite('recur', function() {
     });
 
     verifyFail('WKST=ofo', /invalid WKST/);
+
+    // Zero or negative interval should be accepted as interval=1
+    verify('INTERVAL=0', {
+      interval: 1
+    });
+    verify('INTERVAL=-1', {
+      interval: 1
+    });
   });
 
   test('#toString - round trip', function() {


### PR DESCRIPTION
Right now its possible to add an RRULE with INTERVAL=0 or INTERVAL=-1. This will go through and as soon as we start iterating occurrences we will either throw an exception ("protecting you from death by recursion") with INTERVAL=0 and I haven't checked what happens with INTERVAL=-1 (likely death by recursion).

This patch assumes 1 when reading in a such RRULE. I haven't gone so far to check this.rule.interval each time, I think this check should be enough.

Complete with test and browser build, I hope I didn't miss anything this time.
