### PR TITLE
Add numericDayToIcalDay method

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -4201,6 +4201,19 @@ ICAL.TimezoneService = (function() {
     return DOW_MAP[string];
   };
 
+  /**
+   * Convert a numeric day value into its ical representation (SU, MO, etc..)
+   *
+   * @param {Numeric} numeric value of given day.
+   * @return {String} day ical day.
+   */
+  ICAL.Recur.numericDayToIcalDay = function toIcalDay(num) {
+    //XXX: this is here so we can deal with possibly invalid number values.
+    //     Also, this allows consistent mapping between day numbers and day
+    //     names for external users.
+    return REVERSE_DOW_MAP[num];
+  };
+
   var VALID_DAY_NAMES = /^(SU|MO|TU|WE|TH|FR|SA)$/;
   var VALID_BYDAY_PART = /^([+-])?(5[0-3]|[1-4][0-9]|[1-9])?(SU|MO|TU|WE|TH|FR|SA)$/
   var ALLOWED_FREQ = ['SECONDLY', 'MINUTELY', 'HOURLY',
@@ -4435,8 +4448,8 @@ ICAL.RecurIterator = (function() {
             this.last.day += dow;
           }
         } else {
-          var wkMap = icalrecur_iterator._wkdayMap[this.dtstart.dayOfWeek()];
-          parts.BYDAY = [wkMap];
+          var dayName = ICAL.Recur.numericDayToIcalDay(this.dtstart.dayOfWeek());
+          parts.BYDAY = [dayName];
         }
       }
 
@@ -5434,7 +5447,7 @@ ICAL.RecurIterator = (function() {
       return (this.check_contract_restriction("BYSECOND", this.last.second) &&
               this.check_contract_restriction("BYMINUTE", this.last.minute) &&
               this.check_contract_restriction("BYHOUR", this.last.hour) &&
-              this.check_contract_restriction("BYDAY", icalrecur_iterator._wkdayMap[dow]) &&
+              this.check_contract_restriction("BYDAY", ICAL.Recur.numericDayToIcalDay(dow)) &&
               this.check_contract_restriction("BYWEEKNO", weekNo) &&
               this.check_contract_restriction("BYMONTHDAY", this.last.day) &&
               this.check_contract_restriction("BYMONTH", this.last.month) &&
@@ -5477,8 +5490,6 @@ ICAL.RecurIterator = (function() {
     }
 
   };
-
-  icalrecur_iterator._wkdayMap = ["", "SU", "MO", "TU", "WE", "TH", "FR", "SA"];
 
   icalrecur_iterator._indexMap = {
     "BYSECOND": 0,

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -203,6 +203,19 @@
     return DOW_MAP[string];
   };
 
+  /**
+   * Convert a numeric day value into its ical representation (SU, MO, etc..)
+   *
+   * @param {Numeric} numeric value of given day.
+   * @return {String} day ical day.
+   */
+  ICAL.Recur.numericDayToIcalDay = function toIcalDay(num) {
+    //XXX: this is here so we can deal with possibly invalid number values.
+    //     Also, this allows consistent mapping between day numbers and day
+    //     names for external users.
+    return REVERSE_DOW_MAP[num];
+  };
+
   var VALID_DAY_NAMES = /^(SU|MO|TU|WE|TH|FR|SA)$/;
   var VALID_BYDAY_PART = /^([+-])?(5[0-3]|[1-4][0-9]|[1-9])?(SU|MO|TU|WE|TH|FR|SA)$/
   var ALLOWED_FREQ = ['SECONDLY', 'MINUTELY', 'HOURLY',

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -142,8 +142,8 @@ ICAL.RecurIterator = (function() {
             this.last.day += dow;
           }
         } else {
-          var wkMap = icalrecur_iterator._wkdayMap[this.dtstart.dayOfWeek()];
-          parts.BYDAY = [wkMap];
+          var dayName = ICAL.Recur.numericDayToIcalDay(this.dtstart.dayOfWeek());
+          parts.BYDAY = [dayName];
         }
       }
 
@@ -1141,7 +1141,7 @@ ICAL.RecurIterator = (function() {
       return (this.check_contract_restriction("BYSECOND", this.last.second) &&
               this.check_contract_restriction("BYMINUTE", this.last.minute) &&
               this.check_contract_restriction("BYHOUR", this.last.hour) &&
-              this.check_contract_restriction("BYDAY", icalrecur_iterator._wkdayMap[dow]) &&
+              this.check_contract_restriction("BYDAY", ICAL.Recur.numericDayToIcalDay(dow)) &&
               this.check_contract_restriction("BYWEEKNO", weekNo) &&
               this.check_contract_restriction("BYMONTHDAY", this.last.day) &&
               this.check_contract_restriction("BYMONTH", this.last.month) &&
@@ -1184,8 +1184,6 @@ ICAL.RecurIterator = (function() {
     }
 
   };
-
-  icalrecur_iterator._wkdayMap = ["", "SU", "MO", "TU", "WE", "TH", "FR", "SA"];
 
   icalrecur_iterator._indexMap = {
     "BYSECOND": 0,

--- a/test/recur_test.js
+++ b/test/recur_test.js
@@ -386,5 +386,26 @@ suite('recur', function() {
       }(map));
     }
   });
+  suite('ICAL.Recur#numericDayToIcalDay', function() {
+    var expected = {}
+    expected[Time.SUNDAY] = 'SU';
+    expected[Time.MONDAY] = 'MO';
+    expected[Time.TUESDAY] = 'TU';
+    expected[Time.WEDNESDAY] = 'WE';
+    expected[Time.THURSDAY] = 'TH';
+    expected[Time.FRIDAY] = 'FR';
+    expected[Time.SATURDAY] = 'SA';
+
+    for (var map in expected) {
+      (function(map) {
+        test(map + ' to ' + expected[map], function() {
+          assert.equal(
+            ICAL.Recur.numericDayToIcalDay(map),
+            expected[map]
+          );
+        });
+      }(map));
+    }
+  });
 
  });


### PR DESCRIPTION
This method was useful in the Lightning wrapper, and it also means we can eliminate the extra map in the recur iterator.
