### PR TITLE
Vales not correctly hydrated in getAllProperties

### DIFF
--- a/lib/ical/component.js
+++ b/lib/ical/component.js
@@ -27,6 +27,19 @@ ICAL.Component = (function() {
   }
 
   Component.prototype = {
+    /**
+     * Hydrated properties are inserted into the _properties array at the same
+     * position as in the jCal array, so its possible the array contains
+     * undefined values for unhydrdated properties. To avoid iterating the
+     * array when checking if all properties have been hydrated, we save the
+     * count here.
+     */
+    _hydratedPropertyCount: 0,
+
+    /**
+     * The same count as for _hydratedPropertyCount, but for subcomponents
+     */
+    _hydratedComponentCount: 0,
 
     get name() {
       return this.jCal[NAME_INDEX];
@@ -35,6 +48,7 @@ ICAL.Component = (function() {
     _hydrateComponent: function(index) {
       if (!this._components) {
         this._components = [];
+        this._hydratedComponentCount = 0;
       }
 
       if (this._components[index]) {
@@ -46,12 +60,14 @@ ICAL.Component = (function() {
         this
       );
 
+      this._hydratedComponentCount++;
       return this._components[index] = comp;
     },
 
     _hydrateProperty: function(index) {
       if (!this._properties) {
         this._properties = [];
+        this._hydratedPropertyCount = 0;
       }
 
       if (this._properties[index]) {
@@ -63,6 +79,7 @@ ICAL.Component = (function() {
         this
       );
 
+      this._hydratedPropertyCount++;
       return this._properties[index] = prop;
     },
 
@@ -118,7 +135,7 @@ ICAL.Component = (function() {
         return result;
       } else {
         if (!this._components ||
-            (this._components.length !== jCalLen)) {
+            (this._hydratedComponentCount !== jCalLen)) {
           var i = 0;
           for (; i < jCalLen; i++) {
             this._hydrateComponent(i);
@@ -216,7 +233,7 @@ ICAL.Component = (function() {
         return result;
       } else {
         if (!this._properties ||
-            (this._properties.length !== jCalLen)) {
+            (this._hydratedPropertyCount !== jCalLen)) {
           var i = 0;
           for (; i < jCalLen; i++) {
             this._hydrateProperty(i);
@@ -298,10 +315,12 @@ ICAL.Component = (function() {
     addSubcomponent: function(component) {
       if (!this._components) {
         this._components = [];
+        this._hydratedComponentCount = 0;
       }
 
       var idx = this.jCal[COMPONENT_INDEX].push(component.jCal);
       this._components[idx - 1] = component;
+      this._hydratedComponentCount++;
     },
 
     /**
@@ -312,7 +331,11 @@ ICAL.Component = (function() {
      * @return {Boolean} true when comp is removed.
      */
     removeSubcomponent: function(nameOrComp) {
-      return this._removeObject(COMPONENT_INDEX, '_components', nameOrComp);
+      var removed = this._removeObject(COMPONENT_INDEX, '_components', nameOrComp);
+      if (removed) {
+        this._hydratedComponentCount--;
+      }
+      return removed;
     },
 
     /**
@@ -322,7 +345,9 @@ ICAL.Component = (function() {
      * @param {String} [name] (lowercase) component name.
      */
     removeAllSubcomponents: function(name) {
-      return this._removeAllObjects(COMPONENT_INDEX, '_components', name);
+      var removed = this._removeAllObjects(COMPONENT_INDEX, '_components', name);
+      this._hydratedComponentCount = 0;
+      return removed;
     },
 
     /**
@@ -340,9 +365,11 @@ ICAL.Component = (function() {
 
       if (!this._properties) {
         this._properties = [];
+        this._hydratedPropertyCount = 0;
       }
 
       this._properties[idx - 1] = property;
+      this._hydratedPropertyCount++;
     },
 
     /**
@@ -388,7 +415,11 @@ ICAL.Component = (function() {
      * @return {Boolean} true when deleted.
      */
     removeProperty: function(nameOrProp) {
-      return this._removeObject(PROPERTY_INDEX, '_properties', nameOrProp);
+      var removed = this._removeObject(PROPERTY_INDEX, '_properties', nameOrProp);
+      if (removed) {
+        this._hydratedPropertyCount--;
+      }
+      return removed;
     },
 
     /**
@@ -397,7 +428,9 @@ ICAL.Component = (function() {
      * @param {String} [name] (lowecase) optional property name.
      */
     removeAllProperties: function(name) {
-      return this._removeAllObjects(PROPERTY_INDEX, '_properties', name);
+      var removed = this._removeAllObjects(PROPERTY_INDEX, '_properties', name);
+      this._hydratedPropertyCount = 0;
+      return removed;
     },
 
     toJSON: function() {

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -124,6 +124,22 @@ suite('Component', function() {
       assert.equal(subject.name, 'foo');
       assert.ok(!subject.getAllSubcomponents());
     });
+
+    test('with name from end', function() {
+      // We need our own subject for this test
+      var oursubject = new ICAL.Component(fixtures.components);
+
+      // Get one from the end first
+      var comps = fixtures.components[2];
+      oursubject.getAllSubcomponents(comps[comps.length - 1][0]);
+
+      // Now get them all, they MUST be hydrated
+      var results = oursubject.getAllSubcomponents();
+      for (var i = 0; i < results.length; i++) {
+        assert.isDefined(results[i]);
+        assert.equal(results[i].jCal, subject.jCal[2][i]);
+      }
+    });
   });
 
   test('#addSubcomponent', function() {
@@ -271,6 +287,22 @@ suite('Component', function() {
       results.forEach(function(item, i) {
         assert.equal(item.jCal, subject.jCal[1][i]);
       });
+    });
+
+    test('with name from end', function() {
+      // We need our own subject for this test
+      var oursubject = new ICAL.Component(fixtures.components);
+
+      // Get one from the end first
+      var props = fixtures.components[1];
+      oursubject.getAllProperties(props[props.length - 1][0]);
+
+      // Now get them all, they MUST be hydrated
+      var results = oursubject.getAllProperties();
+      for (var i = 0; i < results.length; i++) {
+        assert.isDefined(results[i]);
+        assert.equal(results[i].jCal, subject.jCal[1][i]);
+      }
     });
   });
 


### PR DESCRIPTION
I don't have a reduced testcase yet, but I have the situation where some values are hydrated, others are not. Then I call `getAllProperties()` and expect to get them all. Lets say properties (by index) 1, 2, 3, 5, 6 are hydrated, 4 is not. The array you get in return is:

[object Object], [object Object], [object Object],,[object Object], [object Object]

The problem is a check like this:

``` javascript
if (!this._properties && this._properties.length !== jCalLen) {
...
}
```

Since the 6th element of the array is already there, the length of the array is 6, even though element 4 is missing.

The quickest possible (js1.6) cure is to use `this._properties.filter(Boolean).length`, but this might be a performance issue. 
