### PR TITLE
Should setValue() first remove all values?

### DIFF
--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -236,11 +236,14 @@ ICAL.Property = (function() {
     },
 
     /**
-     * Sets the current value of the property.
+     * Sets the current value of the property. If this is a multi-value
+     * property, all other values will be removed.
      *
      * @param {String|Object} value new prop value.
      */
     setValue: function(value) {
+      this.removeAllValues();
+
       if (this.isDecorated) {
         this._setDecoratedValue(value, 0);
       } else {

--- a/test/property_test.js
+++ b/test/property_test.js
@@ -367,6 +367,14 @@ suite('Property', function() {
       subject.setValue('xxx');
       assert.equal(subject.getFirstValue(), 'xxx');
     });
+
+    test('multivalue property', function() {
+      var subject = new ICAL.Property("categories");
+      subject.setValues(["work", "play"]);
+      subject.setValue("home");
+      assert.deepEqual(subject.getValues(), ["home"]);
+      assert.equal(subject.getFirstValue(), "home");
+    });
   });
 
   test('#toJSON', function() {


### PR DESCRIPTION
Lets say you have a multi-value ICAL.Property. Then you call `prop.setValue("FOO")` on it. Unless I have another bug in my code, this will set the first value to FOO, but leave all remaining values intact.

I would say calling setValue() should remove all remaining values if its a multi-value property. @lightsofapollo do you agree?
