### PR TITLE
Sane ICAL.Event time handling....

### DIFF
--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -361,33 +361,35 @@ ICAL.Event = (function() {
      * We will not add/remove/update the VTIMEZONE subcomponents
      *  leading to invalid ICAL data...
      */
-    _setTime: function(name, value) {
-      var currentProp = this.component.getFirstProperty(name);
-      var currentValue;
+    _setTime: function(propName, time) {
+      var prop = this.component.getFirstProperty(propName);
 
-      if (currentProp && (currentValue = currentProp.getFirstValue())) {
-        var newTzid = value.zone.tzid;
-        var currentTzid = currentProp.getParameter('tzid');
-
-        if (currentTzid !== newTzid) {
-          /**
-           * Both the localTimezone and the utcTimezone avoid TZID.
-           * We must remove the tzid param in these cases otherwise
-           * the time is either wrong or invalid.
-           */
-          if (
-            value.zone === ICAL.Timezone.localTimezone ||
-            value.zone === ICAL.Timezone.utcTimezone
-          ) {
-            currentProp.removeParameter('tzid');
-          } else {
-            // for the case where we are switching between to timezones.
-            currentProp.setParameter('tzid', newTzid);
-          }
-        }
+      if (!prop) {
+        prop = new ICAL.Property(propName);
+        this.component.addProperty(prop);
       }
 
-      this._setProp(name, value);
+      // type conversion
+      if (time.isDate && prop.type !== 'date') {
+        prop.resetType('date');
+      }
+
+      if (!time.isDate && prop.type !== 'date-time') {
+        prop.resetType('date-time');
+      }
+
+      // utc and local don't get a tzid
+      if (
+        time.zone === ICAL.Timezone.localTimezone ||
+        time.zone === ICAL.Timezone.utcTimezone
+      ) {
+        // remove the tzid
+        prop.removeParameter('tzid');
+      } else {
+        prop.setParameter('tzid', time.zone.tzid);
+      }
+
+      prop.setValue(time);
     },
 
     _setProp: function(name, value) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -106,7 +106,7 @@
       var path = 'samples/timezones/' + zone + '.ics';
       testSupport.load(path, function(err, data) {
         if (err) {
-          done(err);
+          callback(err);
         }
         var zone = register(data);
         this._timezones[zone] = data;


### PR DESCRIPTION
ICAL.Event was fairly dumb when it came to handling.. It would not update the type nor the TZID which caused a bunch of exciting problems as you can imagine...

Now when setting the startDate or endDate we will handle the property type conversion and TZID handling... The VTIMEZONE component adding/removing is not handled here but we should look at where that _should_ go soon. (Works fine manually obviously but it is not very clear how to handle that at this point).
