### PR TITLE
Add function to get default type and fix auto-setting prop.type

### DIFF
--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -369,15 +369,6 @@ ICAL.Event = (function() {
         this.component.addProperty(prop);
       }
 
-      // type conversion
-      if (time.isDate && prop.type !== 'date') {
-        prop.resetType('date');
-      }
-
-      if (!time.isDate && prop.type !== 'date-time') {
-        prop.resetType('date-time');
-      }
-
       // utc and local don't get a tzid
       if (
         time.zone === ICAL.Timezone.localTimezone ||

--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -154,6 +154,22 @@ ICAL.Property = (function() {
     },
 
     /**
+     * Get the default type based on this property's name.
+     *
+     * @return {String} the default type for this property.
+     */
+    getDefaultType: function() {
+      var name = this.name
+      if (name in design.property) {
+        var details = design.property[name];
+        if ('defaultType' in details) {
+          return details.defaultType;
+        }
+      }
+      return null;
+    },
+
+    /**
      * Sets type of property and clears out any
      * existing values of the current type.
      *
@@ -224,6 +240,12 @@ ICAL.Property = (function() {
       var i = 0;
       this.removeAllValues();
 
+      if (len > 0 &&
+          typeof(values[0]) === 'object' &&
+          'icaltype' in values[0]) {
+        this.resetType(values[0].icaltype);
+      }
+
       if (this.isDecorated) {
         for (; i < len; i++) {
           this._setDecoratedValue(values[i], i);
@@ -243,12 +265,16 @@ ICAL.Property = (function() {
      */
     setValue: function(value) {
       this.removeAllValues();
+      if (typeof(value) === 'object' && 'icaltype' in value) {
+        this.resetType(value.icaltype);
+      }
 
       if (this.isDecorated) {
         this._setDecoratedValue(value, 0);
       } else {
         this.jCal[VALUE_INDEX] = value;
       }
+
     },
 
     /**

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -137,6 +137,8 @@
         this.isDate = aData.isDate;
       }
 
+      this.icaltype = (this.isDate ? "date" : "date-time");
+
       if (aData && "timezone" in aData) {
         var zone = ICAL.TimezoneService.get(
           aData.timezone

--- a/test/property_test.js
+++ b/test/property_test.js
@@ -191,7 +191,7 @@ suite('Property', function() {
 
   test('#resetType', function() {
     var subject = new ICAL.Property('dtstart');
-    subject.setValue(new ICAL.Time({ year: 2012 }));
+    subject.setValue(new ICAL.Time({ year: 2012, hour: 10, minute: 1 }));
 
     assert.equal(subject.type, 'date-time');
 
@@ -202,6 +202,30 @@ suite('Property', function() {
     subject.setValue(new ICAL.Time({ year: 2012 }));
 
     var ical = subject.toICAL();
+  });
+
+  suite('#getDefaultType', function() {
+    test('known type', function() {
+      var subject = new ICAL.Property('dtstart');
+      subject.setValue(new ICAL.Time({ year: 2012, hour: 20 }));
+
+      assert.equal(subject.type, 'date-time');
+      assert.equal(subject.getDefaultType(), 'date-time');
+
+      subject.setValue(new ICAL.Time({ year: 2012 }));
+
+      assert.equal(subject.type, 'date');
+      assert.equal(subject.getDefaultType(), 'date-time');
+    });
+
+    test('unknown type', function() {
+      var subject = new ICAL.Property('x-unknown');
+      subject.setValue(new ICAL.Time({ year: 2012, hour: 20 }));
+
+      assert.equal(subject.getFirstValue().icaltype, 'date-time');
+      assert.equal(subject.type, 'date-time');
+      assert.isNull(subject.getDefaultType());
+    });
   });
 
   suite('#getFirstValue', function() {
@@ -327,6 +351,7 @@ suite('Property', function() {
       subject.setValue('2012-09-01T13:00:00');
       var value = subject.getFirstValue();
 
+      assert.equal(subject.type, 'date-time');
       assert.instanceOf(value, ICAL.Time);
 
       assert.hasProperties(value, {
@@ -349,10 +374,11 @@ suite('Property', function() {
       });
 
       subject.setValue(time);
+      assert.equal(subject.type, 'date');
 
       assert.equal(
         subject.jCal[3],
-        ICAL.design.value['date-time'].undecorate(time)
+        ICAL.design.value['date'].undecorate(time)
       );
 
       assert.equal(


### PR DESCRIPTION
Hey @lightsofapollo, @KevinGrandon,

I have a few fixes here that change type setting. I noticed there was no function to get the default type without messing around in the design data.

Then I noticed, that setting an  ICAL.Time with isDate=true doesn't automatically change the type to "date", even though we have an icaltype member that would tell us just this.

This patch fixes both issues, I'd appreciate if one of you could take a look.
