### PR TITLE
Allow empty object for period, add toICALString method for duration

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -2419,30 +2419,26 @@ ICAL.Binary = (function() {
   ICAL.Period = function icalperiod(aData) {
     this.wrappedJSObject = this;
 
-    if (!aData) {
-        throw new Error('Period must be initialized with data');
-    }
-
-    if ('start' in aData) {
-      if (!(aData.start instanceof ICAL.Time)) {
+    if (aData && 'start' in aData) {
+      if (aData.start && !(aData.start instanceof ICAL.Time)) {
         throw new TypeError('.start must be an instance of ICAL.Time');
       }
       this.start = aData.start;
     }
 
-    if (('end' in aData) && ('duration' in aData)) {
+    if (aData && ('end' in aData) && ('duration' in aData)) {
       throw new Error('cannot accept both end and duration');
     }
 
-    if ('end' in aData) {
-      if (!(aData.end instanceof ICAL.Time)) {
+    if (aData && 'end' in aData) {
+      if (aData.end && !(aData.end instanceof ICAL.Time)) {
         throw new TypeError('.end must be an instance of ICAL.Time');
       }
       this.end = aData.end;
     }
 
-    if ('duration' in aData) {
-      if (!(aData.duration instanceof ICAL.Duration)) {
+    if (aData && 'duration' in aData) {
+      if (aData.duration && !(aData.duration instanceof ICAL.Duration)) {
         throw new TypeError('.duration must be an instance of ICAL.Duration');
       }
       this.duration = aData.duration;
@@ -2465,8 +2461,23 @@ ICAL.Binary = (function() {
       }
     },
 
+    getEnd: function() {
+      if (this.end) {
+        return this.end;
+      } else {
+        var end = this.start.clone();
+        end.addDuration(this.duration);
+        return end;
+      }
+    },
+
     toString: function toString() {
       return this.start + "/" + (this.end || this.duration);
+    },
+
+    toICALString: function() {
+      return this.start.toICALString() + "/" +
+             (this.end || this.duration).toICALString();
     }
   };
 
@@ -2613,6 +2624,10 @@ ICAL.Binary = (function() {
         }
         return str;
       }
+    },
+
+    toICALString: function() {
+      return this.toString();
     }
   };
 

--- a/lib/ical/duration.js
+++ b/lib/ical/duration.js
@@ -112,6 +112,10 @@
         }
         return str;
       }
+    },
+
+    toICALString: function() {
+      return this.toString();
     }
   };
 

--- a/lib/ical/period.js
+++ b/lib/ical/period.js
@@ -10,30 +10,26 @@
   ICAL.Period = function icalperiod(aData) {
     this.wrappedJSObject = this;
 
-    if (!aData) {
-        throw new Error('Period must be initialized with data');
-    }
-
-    if ('start' in aData) {
-      if (!(aData.start instanceof ICAL.Time)) {
+    if (aData && 'start' in aData) {
+      if (aData.start && !(aData.start instanceof ICAL.Time)) {
         throw new TypeError('.start must be an instance of ICAL.Time');
       }
       this.start = aData.start;
     }
 
-    if (('end' in aData) && ('duration' in aData)) {
+    if (aData && ('end' in aData) && ('duration' in aData)) {
       throw new Error('cannot accept both end and duration');
     }
 
-    if ('end' in aData) {
-      if (!(aData.end instanceof ICAL.Time)) {
+    if (aData && 'end' in aData) {
+      if (aData.end && !(aData.end instanceof ICAL.Time)) {
         throw new TypeError('.end must be an instance of ICAL.Time');
       }
       this.end = aData.end;
     }
 
-    if ('duration' in aData) {
-      if (!(aData.duration instanceof ICAL.Duration)) {
+    if (aData && 'duration' in aData) {
+      if (aData.duration && !(aData.duration instanceof ICAL.Duration)) {
         throw new TypeError('.duration must be an instance of ICAL.Duration');
       }
       this.duration = aData.duration;
@@ -56,8 +52,23 @@
       }
     },
 
+    getEnd: function() {
+      if (this.end) {
+        return this.end;
+      } else {
+        var end = this.start.clone();
+        end.addDuration(this.duration);
+        return end;
+      }
+    },
+
     toString: function toString() {
       return this.start + "/" + (this.end || this.duration);
+    },
+
+    toICALString: function() {
+      return this.start.toICALString() + "/" +
+             (this.end || this.duration).toICALString();
     }
   };
 

--- a/test/duration_test.js
+++ b/test/duration_test.js
@@ -76,6 +76,7 @@ suite('ical/duration', function() {
         }
         subject.normalize();
         assert.equal(subject.toString(), str);
+        assert.equal(subject.toICALString(), str);
       });
     }
 


### PR DESCRIPTION
For my use case I do something like this:

``` javascript
var f = new ICAL.Period();
...
f.start = somestart;
f.end = someend;
```

This patch allows creating an empty ICAL.Period object. It also adds a getter for the End date thats independent of if duration or end was passed.
