### PR TITLE
Fix expanding timezone into the future

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -2948,7 +2948,7 @@ ICAL.Binary = (function() {
         }
 
         this.changes.sort(ICAL.Timezone._compare_change_fn);
-        this.expandedUntilYear = aYear;
+        this.expandedUntilYear = changesEndYear;
       }
     },
 

--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -219,7 +219,7 @@
         }
 
         this.changes.sort(ICAL.Timezone._compare_change_fn);
-        this.expandedUntilYear = aYear;
+        this.expandedUntilYear = changesEndYear;
       }
     },
 

--- a/test/timezone_test.js
+++ b/test/timezone_test.js
@@ -138,13 +138,20 @@ suite('timezone', function() {
   });
 
   timezoneTest('America/Los_Angeles', '#expandedUntilYear', function() {
+
+    function calcYear(yr) {
+        return Math.max(ICAL.Timezone._minimumExpansionYear, yr) +
+               ICAL.Timezone.EXTRA_COVERAGE;
+    }
+
     var time = new ICAL.Time({
       year: 2012,
       zone: timezone
     });
+    var expectedCoverage = calcYear(time.year);
 
     time.utcOffset();
-    assert.equal(timezone.expandedUntilYear, 2012);
+    assert.equal(timezone.expandedUntilYear, expectedCoverage);
 
     time = new ICAL.Time({
       year: 2014,
@@ -152,21 +159,29 @@ suite('timezone', function() {
     });
 
     time.utcOffset();
-    assert.equal(timezone.expandedUntilYear, 2014);
+    assert.equal(timezone.expandedUntilYear, expectedCoverage);
 
     time = new ICAL.Time({
       year: 1997,
       zone: timezone
     });
     time.utcOffset();
-    assert.equal(timezone.expandedUntilYear, 2014);
+    assert.equal(timezone.expandedUntilYear, expectedCoverage);
+
+    time = new ICAL.Time({
+      year: expectedCoverage + 3,
+      zone: timezone
+    });
+    expectedCoverage = calcYear(time.year);
+    time.utcOffset();
+    assert.equal(timezone.expandedUntilYear, expectedCoverage);
 
     time = new ICAL.Time({
       year: ICAL.Timezone.MAX_YEAR + 1,
       zone: timezone
     });
     time.utcOffset();
-    assert.equal(timezone.expandedUntilYear, ICAL.Timezone.MAX_YEAR + 1);
+    assert.equal(timezone.expandedUntilYear, ICAL.Timezone.MAX_YEAR);
   });
 
   suite('#convertTime', function() {


### PR DESCRIPTION
This makes sure timezone expansion is actually saved. Not doing this will do the whole expansion for each year. Since these are internal details and you are working on a new expansion engine, it probably doesn't make sense to add tests. r? @lightsofapollo
