### PR TITLE
Components and properties must only have one parent

### DIFF
--- a/lib/ical/component.js
+++ b/lib/ical/component.js
@@ -21,9 +21,7 @@ ICAL.Component = (function() {
     // mostly for legacy reasons.
     this.jCal = jCal;
 
-    if (parent) {
-      this.parent = parent;
-    }
+    this.parent = parent || null;
   }
 
   Component.prototype = {
@@ -249,6 +247,10 @@ ICAL.Component = (function() {
     _removeObjectByIndex: function(jCalIndex, cache, index) {
       // remove cached version
       if (cache && cache[index]) {
+        var obj = cache[index];
+        if ("parent" in obj) {
+            obj.parent = null;
+        }
         cache.splice(index, 1);
       }
 
@@ -284,26 +286,17 @@ ICAL.Component = (function() {
     _removeAllObjects: function(jCalIndex, cache, name) {
       var cached = this[cache];
 
-      if (name) {
-        var objects = this.jCal[jCalIndex];
-        var i = objects.length - 1;
+      // Unfortunately we have to run through all children to reset their
+      // parent property.
+      var objects = this.jCal[jCalIndex];
+      var i = objects.length - 1;
 
-        // descending search required because splice
-        // is used and will effect the indices.
-        for (; i >= 0; i--) {
-          if (objects[i][NAME_INDEX] === name) {
-            this._removeObjectByIndex(jCalIndex, cached, i);
-          }
+      // descending search required because splice
+      // is used and will effect the indices.
+      for (; i >= 0; i--) {
+        if (!name || objects[i][NAME_INDEX] === name) {
+          this._removeObjectByIndex(jCalIndex, cached, i);
         }
-      } else {
-        if (cache in this) {
-          // I think its probable that when we remove all
-          // of a type we may want to add to it again so it
-          // makes sense to reuse the object in that case.
-          // For now we remove the contents of the array.
-          this[cache].length = 0;
-        }
-        this.jCal[jCalIndex].length = 0;
       }
     },
 
@@ -318,9 +311,14 @@ ICAL.Component = (function() {
         this._hydratedComponentCount = 0;
       }
 
+      if (component.parent) {
+        component.parent.removeSubcomponent(component);
+      }
+
       var idx = this.jCal[COMPONENT_INDEX].push(component.jCal);
       this._components[idx - 1] = component;
       this._hydratedComponentCount++;
+      component.parent = this;
     },
 
     /**
@@ -360,16 +358,20 @@ ICAL.Component = (function() {
         throw new TypeError('must instance of ICAL.Property');
       }
 
-      var idx = this.jCal[PROPERTY_INDEX].push(property.jCal);
-      property.component = this;
-
       if (!this._properties) {
         this._properties = [];
         this._hydratedPropertyCount = 0;
       }
 
+
+      if (property.parent) {
+        property.parent.removeProperty(property);
+      }
+
+      var idx = this.jCal[PROPERTY_INDEX].push(property.jCal);
       this._properties[idx - 1] = property;
       this._hydratedPropertyCount++;
+      property.parent = this;
     },
 
     /**
@@ -379,10 +381,10 @@ ICAL.Component = (function() {
      * @param {Object} value property value.
      */
     addPropertyWithValue: function(name, value) {
-      var prop = new ICAL.Property(name, this);
+      var prop = new ICAL.Property(name);
       prop.setValue(value);
 
-      this.addProperty(prop, this);
+      this.addProperty(prop);
 
       return prop;
     },

--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -20,9 +20,9 @@ ICAL.Property = (function() {
    * @param {Array|String} jCal raw jCal representation OR
    *  the new name of the property (when creating).
    *
-   * @param {ICAL.Component} [component] parent component.
+   * @param {ICAL.Component} [parent] parent component.
    */
-  function Property(jCal, component) {
+  function Property(jCal, parent) {
     if (typeof(jCal) === 'string') {
       // because we a creating by name we need
       // to find the type when creating the property.
@@ -43,7 +43,7 @@ ICAL.Property = (function() {
     }
 
     this.jCal = jCal;
-    this.component = component;
+    this.parent = parent || null;
     this._updateType();
   }
 

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -39,6 +39,109 @@ suite('Component', function() {
     assert.ok(!newComp.getAllProperties());
   });
 
+  suite('parenting', function() {
+    // Today we hear a tale about Tom, Marge, Bernhard and Claire.
+    var tom, bernhard, claire, marge, relationship
+    var house, otherhouse;
+    setup(function() {
+      tom = new ICAL.Component("tom");
+      bernhard = new ICAL.Component("bernhard");
+      claire = new ICAL.Component("claire");
+      marge = new ICAL.Component("marge");
+      relationship = new ICAL.Component("vrelationship");
+      house = new ICAL.Property("house");
+      otherhouse = new ICAL.Property("otherhouse");
+    });
+
+    test('basic', function() {
+      // Tom and Bernhard are best friends. They are happy and single.
+      assert.isNull(tom.parent);
+      assert.isNull(bernhard.parent);
+
+      // One day, they get to know Marge, who is also single.
+      assert.isNull(marge.parent);
+
+      // Tom and Bernhard play rock paper scissors on who gets a first shot at
+      // Marge and Tom wins. After a few nice dates they get together.
+      relationship.addSubcomponent(tom);
+      relationship.addSubcomponent(marge);
+
+      // Both are happy as can be and tell everyone about their love. Nothing
+      // goes above their relationship!
+      assert.isNull(relationship.parent);
+      assert.equal(tom.parent, relationship);
+      assert.equal(marge.parent, relationship);
+
+      // Over the years, there are a few ups and downs.
+      relationship.removeSubcomponent(tom);
+      assert.isNull(relationship.parent);
+      assert.isNull(tom.parent);
+      assert.equal(marge.parent, relationship);
+      relationship.removeAllSubcomponents();
+      assert.isNull(marge.parent);
+
+      // But in the end they stay together.
+      relationship.addSubcomponent(tom);
+      relationship.addSubcomponent(marge);
+    });
+
+    test('multiple children', function() {
+      // After some happy years Tom and Marge get married. Tom is going to be father
+      // of his beautiful daughter Claire.
+      tom.addSubcomponent(claire);
+
+      // He has no doubt he is the father
+      assert.equal(claire.parent, tom);
+
+      // One day, Tom catches his wife in bed with his best friend Bernhard.
+      // Tom is very unhappy and requests a paternity test. It turns out that
+      // Claire is actually Bernhard's daughter.
+      bernhard.addSubcomponent(claire);
+
+      // Marge knew it all along. What a sad day. Claire is not Tom's daughter,
+      // but instead Bernhard's. Tom has no children, and Bernhard is the happy
+      // father of his daughter claire.
+      assert.equal(claire.parent, bernhard);
+      assert.isNull(tom.getFirstSubcomponent());
+      assert.equal(bernhard.getFirstSubcomponent(), claire);
+    });
+
+    test('properties', function() {
+      // Marge lives on a property near the Hamptons, she thinks it belongs to
+      // her.
+      marge.addProperty(house);
+      assert.equal(house.parent, marge);
+
+      // It seems that Tom didn't always trust Marge, he had fooled her. The
+      // house belongs to him.
+      tom.addProperty(house);
+      assert.equal(house.parent, tom);
+      assert.isNull(marge.getFirstProperty());
+
+      // Bernhard being an aggressive character, tries to throw Tom out of his
+      // own house. A long visit in the hospital lets neighbors believe noone
+      // lives there anymore.
+      tom.removeProperty(house);
+      assert.isNull(house.parent);
+
+      // Marge spends a few nights there, but also lives in her other house.
+      marge.addProperty(house);
+      marge.addProperty(otherhouse);
+      assert.equal(house.parent, marge);
+      assert.equal(otherhouse.parent, marge);
+
+      // Tom is back from the hospital and very mad. He throws marge out of his
+      // house. Unfortunately marge can no longer pay the rent for her other
+      // house either.
+      marge.removeAllProperties();
+      assert.isNull(house.parent);
+      assert.isNull(otherhouse.parent);
+
+      // What a mess. What do we lern from this testsuite? Infidelity is not a
+      // good idea. Always be faithful!
+    });
+  });
+
   suite('#getFirstSubcomponent', function() {
     var jCal;
     setup(function() {
@@ -316,7 +419,7 @@ suite('Component', function() {
     var lastProp = all[all.length - 1];
 
     assert.equal(lastProp, prop);
-    assert.equal(lastProp.component, subject);
+    assert.equal(lastProp.parent, subject);
   });
 
   test('#addPropertyWithValue', function() {


### PR DESCRIPTION
Right now the parent property is not reliably set. We should change this. One downside to this patch is that the removeAll\* methods need to go through all objects to unset the parent. I don't see a good solution to this and I hope this doesn't impact performance too much.
