### PR TITLE
Fix hang on invalid newline inside quoted parameter

### DIFF
--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -238,6 +238,11 @@ ICAL.parse = (function() {
       if (nextChar === '"') {
         var valuePos = pos + 2;
         pos = helpers.unescapedIndexOf(line, '"', valuePos);
+        if (pos === -1) {
+          throw new ParserError(
+            'invalid line (no matching double quote) "' + line + '"'
+          );
+        }
         value = line.substr(valuePos, pos - valuePos);
         lastParam = helpers.unescapedIndexOf(line, PARAM_DELIMITER, pos);
       } else {

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -114,6 +114,18 @@ suite('parserv2', function() {
       }, /invalid line/);
     });
 
+    test('invalid quoted params', function() {
+      var ical = 'BEGIN:VCALENDAR\n';
+      ical += 'X-FOO;BAR="quoted\n';
+      // an invalid newline inside quoted parameter
+      ical += 'params";FOO=baz:realvalue\n';
+      ical += 'END:VCALENDAR';
+
+      assert.throws(function() {
+        subject(ical);
+      }, /invalid line/);
+    });
+
     test('missing component end', function() {
       var ical = 'BEGIN:VCALENDAR\n';
       ical += 'BEGIN:VEVENT\n';


### PR DESCRIPTION
A newline inside quoted parameter that is not the results of folding can cause ical.js parser to hang forever.

Example:

```
BEGIN:VCALENDAR
X-FOO;BAR="quoted
params";FOO=baz:realvalue
END:VCALENDAR
```

This pull request fixes the issue by throwing an error when a line of quoted parameter ends before the ending double quote is found.
