### PR TITLE
Make sandbox/validator.html work in Chrome

### DIFF
--- a/sandbox/validator.html
+++ b/sandbox/validator.html
@@ -35,7 +35,6 @@
         try {
             // First load the source representation
             sourceResult = ICAL.parse(data.value)
-            results.textContent = sourceResult.toSource();
 
             // Try to jsonify it
             jsonResult = JSON.stringify(sourceResult, null, " ");
@@ -57,9 +56,6 @@
             component = new ICAL.Component(sourceResult[1]);
 
             try {
-                // Try to undecorate it
-                undecorated.textContent = component.jCal.toSource();
-
                 // Try to jsonify it
                 jsonResult = JSON.stringify(component, null, " ");
                 undecorated.textContent = jsonResult;


### PR DESCRIPTION
Fixes #112 

The validator makes use of `toSource`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource which is a non-standard method that only works in Firefox. The code that makes use of `toSource` seems to be dead, therefore I'm pretty sure that we can just remove the lines. I tested the changed code in Chrome and Firefox and works.
