### PR TITLE
Fix recur yearly with Bymonth and more Byday

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -5484,8 +5484,6 @@ ICAL.RecurIterator = (function() {
             }
           } else {
             for (var daycodedkey in this.by_data.BYDAY) {
-              //TODO: This should return dates in order of occurrence
-              //      (1,2,3, etc...) instead of by weekday (su, mo, etc..)
               var coded_day = this.by_data.BYDAY[daycodedkey];
               var parts = this.ruleDayOfWeek(coded_day);
               var pos = parts[0];
@@ -5515,6 +5513,9 @@ ICAL.RecurIterator = (function() {
             }
           }
         }
+        // Return dates in order of occurrence (1,2,3,...) instead
+        // of by groups of weekdays (1,8,15,...,2,9,16,...).
+        this.days.sort(function(a,b){return a - b;}); // Comparator function allows to sort numbers.
       } else if (partCount == 2 && "BYDAY" in parts && "BYMONTHDAY" in parts) {
         var expandedDays = this.expand_by_day(aYear);
 

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -943,8 +943,6 @@ ICAL.RecurIterator = (function() {
             }
           } else {
             for (var daycodedkey in this.by_data.BYDAY) {
-              //TODO: This should return dates in order of occurrence
-              //      (1,2,3, etc...) instead of by weekday (su, mo, etc..)
               var coded_day = this.by_data.BYDAY[daycodedkey];
               var parts = this.ruleDayOfWeek(coded_day);
               var pos = parts[0];
@@ -974,6 +972,9 @@ ICAL.RecurIterator = (function() {
             }
           }
         }
+        // Return dates in order of occurrence (1,2,3, etc...)
+        // instead of by weekday (su, mo, etc..).
+        this.days.sort(function(a,b){return a - b;});
       } else if (partCount == 2 && "BYDAY" in parts && "BYMONTHDAY" in parts) {
         var expandedDays = this.expand_by_day(aYear);
 

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -972,9 +972,9 @@ ICAL.RecurIterator = (function() {
             }
           }
         }
-        // Return dates in order of occurrence (1,2,3, etc...)
-        // instead of by weekday (su, mo, etc..).
-        this.days.sort(function(a,b){return a - b;});
+        // Return dates in order of occurrence (1,2,3,...) instead
+        // of by groups of weekdays (1,8,15,...,2,9,16,...).
+        this.days.sort(function(a,b){return a - b;}); // Comparator function allows to sort numbers.
       } else if (partCount == 2 && "BYDAY" in parts && "BYMONTHDAY" in parts) {
         var expandedDays = this.expand_by_day(aYear);
 

--- a/test/recur_iterator_test.js
+++ b/test/recur_iterator_test.js
@@ -268,7 +268,7 @@ suite('recur_iterator', function() {
     });
   });
 
-  suite('yearly & by month', function() {
+  suite('yearly & by month with one by day', function() {
 
     test('infinite', function() {
       var raw = 'FREQ=YEARLY;BYMONTH=3;BYDAY=TU';
@@ -1161,6 +1161,86 @@ suite('recur_iterator', function() {
         new Date(2018, 3, 30, 8),
         new Date(2019, 3, 30, 8)
       ];
+
+      while (inc < max) {
+        var value = iterator.next().toJSDate();
+        dates.push(value);
+        inc++;
+      }
+
+      assert.deepEqual(
+        dates,
+        expected
+      );
+
+    });
+  });
+
+  suite('Yearly, every WE and FR of January and March (more BYMONTH and more BYDAY)', function() {
+    createIterator(
+      'FREQ=YEARLY;BYMONTH=1,3;BYDAY=WE,FR',
+      '2014-01-01T08:00:00'
+    );
+
+    test('for all the occurrences on January and March in the first year', function() {
+      var next;
+      var dates = [];
+
+      assert.isFalse(recur.isFinite(), 'finite');
+
+      var max = 18;
+      var inc = 0;
+
+      var expected = [
+        new Date(2014, 0, 1, 8),  new Date(2014, 0, 3, 8),
+        new Date(2014, 0, 8, 8),  new Date(2014, 0, 10, 8),
+        new Date(2014, 0, 15, 8), new Date(2014, 0, 17, 8),
+        new Date(2014, 0, 22, 8), new Date(2014, 0, 24, 8),
+        new Date(2014, 0, 29, 8), new Date(2014, 0, 31, 8),
+        new Date(2014, 2, 5, 8),  new Date(2014, 2, 7, 8),
+        new Date(2014, 2, 12, 8), new Date(2014, 2, 14, 8),
+        new Date(2014, 2, 19, 8), new Date(2014, 2, 21, 8),
+        new Date(2014, 2, 26, 8), new Date(2014, 2, 28, 8)
+      ];
+
+      while (inc < max) {
+        var value = iterator.next().toJSDate();
+        dates.push(value);
+        inc++;
+      }
+
+      assert.deepEqual(
+        dates,
+        expected
+      );
+
+    });
+  });
+
+  suite('Yearly, every day of January (one BYMONTH and more BYDAY)', function() {
+    createIterator(
+      'FREQ=YEARLY;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA',
+      '2014-01-01T08:00:00'
+    );
+
+    test('for 31 occurrences on January in the first year', function() {
+      var next;
+      var date;
+      var dates = [];
+      var expected = [];
+
+      assert.isFalse(recur.isFinite(), 'finite');
+
+      var max = 31;
+      var inc = 0;
+
+      while (inc < max) {
+        date = new Date(2014, 0, inc + 1, 8);
+        expected.push(date);
+        inc++;
+      }
+
+      inc = 0;
 
       while (inc < max) {
         var value = iterator.next().toJSDate();


### PR DESCRIPTION
It sorts the array of the days according to a Bymonthday order
(1,2,3, ...) instead of a Byday order (Su, Mo, ...).
Fixes Lightning's bug 958978 .
