### PR TITLE
Support of YYYY-MM-DD format in date/datetime.fromICAL()

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -510,8 +510,10 @@ ICAL.design = (function() {
 
           var result = matches[1] + '-' +
                        matches[2] + '-' +
-                       matches[3] +
-                       matches[4]; // Z
+                       matches[3];
+          if (matches.length > 4 ) {
+            result += matches[4];
+          }
           return result;
         },
 
@@ -549,8 +551,10 @@ ICAL.design = (function() {
                        matches[3] + 'T' +
                        matches[4] + ':' +
                        matches[5] + ':' +
-                       matches[6] +
-                       matches[7]; // Z
+                       matches[6];
+          if (matches.length > 7 ) {
+            result += matches[7];
+          }
           return result;
         },
 

--- a/build/ical.js
+++ b/build/ical.js
@@ -501,16 +501,17 @@ ICAL.design = (function() {
         },
 
         fromICAL: function(aValue) {
-          // from: 20120901
-          // to: 2012-09-01
-          var result = aValue.substr(0, 4) + '-' +
-                       aValue.substr(4, 2) + '-' +
-                       aValue.substr(6, 2);
-
-          if (aValue[8] === 'Z') {
-            result += 'Z';
+          // from: 20120901 or 20120901Z or 2012-09-01 or 2012-09-01Z
+          // to: 2012-09-01 or  2012-09-01Z
+          var matches = /^(\d{4})-?(\d{2})-?(\d{2})(Z)?/.exec(aValue);
+          if (!matches) {
+            return aValue;
           }
 
+          var result = matches[1] + '-' +
+                       matches[2] + '-' +
+                       matches[3] +
+                       matches[4]; // Z
           return result;
         },
 
@@ -536,19 +537,20 @@ ICAL.design = (function() {
       },
       "date-time": {
         fromICAL: function(aValue) {
-          // from: 20120901T130000
-          // to: 2012-09-01T13:00:00
-          var result = aValue.substr(0, 4) + '-' +
-                       aValue.substr(4, 2) + '-' +
-                       aValue.substr(6, 2) + 'T' +
-                       aValue.substr(9, 2) + ':' +
-                       aValue.substr(11, 2) + ':' +
-                       aValue.substr(13, 2);
-
-          if (aValue[15] === 'Z') {
-            result += 'Z'
+          // from: 20120901T130000 or  20120901T130000Z or 2012-09-01T13:00:00 or 2012-09-01T13:00:00Z
+          // to: 2012-09-01T13:00:00 or 2012-09-01T13:00:00Z
+          var matches = /^(\d{4})-?(\d{2})-?(\d{2})T(\d{2}):?(\d{2}):?(\d{2})(Z)?/.exec(aValue);
+          if (!matches) {
+            return aValue;
           }
 
+          var result = matches[1] + '-' +
+                       matches[2] + '-' +
+                       matches[3] + 'T' +
+                       matches[4] + ':' +
+                       matches[5] + ':' +
+                       matches[6] +
+                       matches[7]; // Z
           return result;
         },
 

--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -226,8 +226,10 @@ ICAL.design = (function() {
 
           var result = matches[1] + '-' +
                        matches[2] + '-' +
-                       matches[3] +
-                       matches[4]; // Z
+                       matches[3];
+          if (matches.length > 4 ) {
+            result += matches[4];
+          }
           return result;
         },
 
@@ -265,8 +267,10 @@ ICAL.design = (function() {
                        matches[3] + 'T' +
                        matches[4] + ':' +
                        matches[5] + ':' +
-                       matches[6] +
-                       matches[7]; // Z
+                       matches[6];
+          if (matches.length > 7 ) {
+            result += matches[7];
+          }
           return result;
         },
 

--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -217,16 +217,17 @@ ICAL.design = (function() {
         },
 
         fromICAL: function(aValue) {
-          // from: 20120901
-          // to: 2012-09-01
-          var result = aValue.substr(0, 4) + '-' +
-                       aValue.substr(4, 2) + '-' +
-                       aValue.substr(6, 2);
-
-          if (aValue[8] === 'Z') {
-            result += 'Z';
+          // from: 20120901 or 20120901Z or 2012-09-01 or 2012-09-01Z
+          // to: 2012-09-01 or  2012-09-01Z
+          var matches = /^(\d{4})-?(\d{2})-?(\d{2})(Z)?/.exec(aValue);
+          if (!matches) {
+            return aValue;
           }
 
+          var result = matches[1] + '-' +
+                       matches[2] + '-' +
+                       matches[3] +
+                       matches[4]; // Z
           return result;
         },
 
@@ -252,19 +253,20 @@ ICAL.design = (function() {
       },
       "date-time": {
         fromICAL: function(aValue) {
-          // from: 20120901T130000
-          // to: 2012-09-01T13:00:00
-          var result = aValue.substr(0, 4) + '-' +
-                       aValue.substr(4, 2) + '-' +
-                       aValue.substr(6, 2) + 'T' +
-                       aValue.substr(9, 2) + ':' +
-                       aValue.substr(11, 2) + ':' +
-                       aValue.substr(13, 2);
-
-          if (aValue[15] === 'Z') {
-            result += 'Z'
+          // from: 20120901T130000 or  20120901T130000Z or 2012-09-01T13:00:00 or 2012-09-01T13:00:00Z
+          // to: 2012-09-01T13:00:00 or 2012-09-01T13:00:00Z
+          var matches = /^(\d{4})-?(\d{2})-?(\d{2})T(\d{2}):?(\d{2}):?(\d{2})(Z)?/.exec(aValue);
+          if (!matches) {
+            return aValue;
           }
 
+          var result = matches[1] + '-' +
+                       matches[2] + '-' +
+                       matches[3] + 'T' +
+                       matches[4] + ':' +
+                       matches[5] + ':' +
+                       matches[6] +
+                       matches[7]; // Z
           return result;
         },
 

--- a/test/design_test.js
+++ b/test/design_test.js
@@ -52,8 +52,22 @@ suite('design', function() {
         var value = subject.fromICAL(
           '20121010'
         );
-
         assert.equal(value, '2012-10-10');
+
+        value = subject.fromICAL(
+          '2012-10-10'
+        );
+        assert.equal(value, '2012-10-10');
+
+        value = subject.fromICAL(
+          '20121010Z'
+        );
+        assert.equal(value, '2012-10-10Z');
+
+        value = subject.fromICAL(
+          '2012-10-10Z'
+        );
+        assert.equal(value, '2012-10-10Z');
       });
 
       test('#toICAL', function() {
@@ -104,6 +118,11 @@ suite('design', function() {
         assert.equal(
           subject.toICAL(expected),
           value
+        );
+
+        assert.equal(
+          subject.fromICAL(expected),
+          expected
         );
       });
 


### PR DESCRIPTION
Some vcards (probably generated by other tools than ICalendar) may content date in the format YYYY-MM-DD, and not YYYYMMDD.
