### PR TITLE
Check for aData before iterating it

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -3403,10 +3403,12 @@ ICAL.TimezoneService = (function() {
     },
 
     fromData: function fromData(aData, aZone) {
-      for (var key in aData) {
-        // ical type cannot be set
-        if (key === 'icaltype') continue;
-        this[key] = aData[key];
+      if (aData) {
+        for (var key in aData) {
+          // ical type cannot be set
+          if (key === 'icaltype') continue;
+          this[key] = aData[key];
+        }
       }
 
       if (aZone) {

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -127,10 +127,12 @@
     },
 
     fromData: function fromData(aData, aZone) {
-      for (var key in aData) {
-        // ical type cannot be set
-        if (key === 'icaltype') continue;
-        this[key] = aData[key];
+      if (aData) {
+        for (var key in aData) {
+          // ical type cannot be set
+          if (key === 'icaltype') continue;
+          this[key] = aData[key];
+        }
       }
 
       if (aZone) {


### PR DESCRIPTION
Was using the profiler yesterday and noticed a lot of markers about this loop. The JS engine complains that aData isn't an object (I assume it's `undefined`). Not sure if there's a performance gain but there might be a tiny one.
