### PR TITLE
README.md: compact npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jsical - Javascript parser for rfc5545 [![NPM](https://nodei.co/npm/ical.js.png)](https://npmjs.org/package/ical.js)
+# jsical - Javascript parser for rfc5545
 
 This is a library to parse the iCalendar format defined in
 [rfc5545](http://tools.ietf.org/html/rfc5545), as well as similar formats like
@@ -16,7 +16,7 @@ I am also aiming for a caldav.js when this is done. Most algorithms here were
 taken from [libical](https://github.com/libical/libical). If you are bugfixing
 this library, please check if the fix can be upstreamed to libical.
 
-[![Build Status](https://secure.travis-ci.org/mozilla-comm/ical.js.png?branch=master)](http://travis-ci.org/mozilla-comm/ical.js)
+[![Build Status](https://secure.travis-ci.org/mozilla-comm/ical.js.png?branch=master)](http://travis-ci.org/mozilla-comm/ical.js) [![npm version](https://badge.fury.io/js/ical.js.svg)](http://badge.fury.io/js/ical.js)
 
 ## Validator 
 


### PR DESCRIPTION
Fixed as per suggestion by @kewisch from https://github.com/mozilla-comm/ical.js/pull/142#issuecomment-90236910
## Before:

![screen shot 2015-04-07 at 12 15 34 pm](https://cloud.githubusercontent.com/assets/4898263/7030158/d4e0a4f4-dd1f-11e4-81b1-2818187a6f39.png)
## After:

![screen shot 2015-04-07 at 12 16 09 pm](https://cloud.githubusercontent.com/assets/4898263/7030170/ec1d6fc6-dd1f-11e4-96b9-6699dfd85044.png)
