### PR TITLE
Flexible UtcOffset creation

### DIFF
--- a/lib/ical/utc_offset.js
+++ b/lib/ical/utc_offset.js
@@ -1,23 +1,37 @@
 ICAL.UtcOffset = (function() {
 
   function UtcOffset(aData) {
-    if (aData) {
-      this.hours = aData.hours;
-      this.minutes = aData.minutes;
-      this.factor = aData.factor;
-    }
+    this.fromData(aData);
   }
 
   UtcOffset.prototype = {
 
-    hours: null,
-    minutes: null,
-    factor: null,
+    hours: 0,
+    minutes: 0,
+    factor: 1,
 
     icaltype: "utc-offset",
 
-    toSeconds: function() {
-      return this.factor * (60 * this.minutes + 3600 * this.hours);
+    /**
+     * Internal uses to indicate that a change has been made and the next read
+     * operation must attempt to normalize the value
+     *
+     * @type {Boolean}
+     * @private
+     */
+    _pendingNormalization: false,
+
+    clone: function() {
+      return ICAL.UtcOffset.fromSeconds(this.toSeconds());
+    },
+
+    fromData: function(aData) {
+      if (aData) {
+        for (var key in aData) {
+          this[key] = aData[key];
+        }
+      }
+      this._normalize();
     },
 
     fromSeconds: function(aSeconds) {
@@ -31,6 +45,38 @@ ICAL.UtcOffset = (function() {
       return this;
     },
 
+    toSeconds: function() {
+      return this.factor * (60 * this.minutes + 3600 * this.hours);
+    },
+
+    compare: function icaltime_compare(other) {
+      var a = this.toSeconds();
+      var b = other.toSeconds();
+      return (a > b) - (b > a);
+    },
+
+    _normalize: function() {
+      // Range: 97200 seconds (with 1 hour inbetween)
+      var secs = this.toSeconds();
+      var factor = this.factor;
+      while (secs < -43200) { // = UTC-12:00
+        secs += 97200;
+      }
+      while (secs > 50400) { // = UTC+14:00
+        secs -= 97200;
+      }
+
+      this.fromSeconds(secs);
+
+      // Avoid changing the factor when on zero seconds
+      if (secs == 0) {
+        this.factor = factor;
+      }
+    },
+
+    toICALString: function() {
+      return ICAL.design.icalendar.value['utc-offset'].toICAL(this.toString());
+    },
 
     toString: function toString() {
       return (this.factor == 1 ? "+" : "-") +

--- a/test/utc_offset_test.js
+++ b/test/utc_offset_test.js
@@ -1,4 +1,105 @@
 suite('ICAL.UtcOffset', function() {
+  test('#clone', function() {
+    var subject = new ICAL.UtcOffset({ hours: 5, minutes: 6 });
+    assert.equal(subject.toString(), "+05:06");
+
+    var cloned = subject.clone();
+    subject.hours = 6;
+
+    assert.equal(cloned.toString(), "+05:06");
+    assert.equal(subject.toString(), "+06:06");
+  });
+
+  test('#toICALString', function() {
+    var subject = new ICAL.UtcOffset({ hours: 5, minutes: 6 });
+    assert.equal(subject.toString(), "+05:06");
+    assert.equal(subject.toICALString(), "+0506");
+  });
+
+  suite('#normalize', function() {
+    test('minute overflow', function() {
+      assert.hasProperties(new ICAL.UtcOffset({
+        minutes: 120
+      }), {
+        hours: 2, minutes: 0, factor: 1
+      });
+    });
+    test('minutes underflow', function() {
+      assert.hasProperties(new ICAL.UtcOffset({
+        minutes: -120
+      }), {
+        hours: 2, minutes: 0, factor: -1
+      });
+    });
+    test('minutes underflow with hours', function() {
+      assert.hasProperties(new ICAL.UtcOffset({
+        hours: 2,
+        minutes: -120
+      }), {
+        hours: 0, minutes: 0, factor: 1
+      });
+    });
+    test('hours overflow', function() {
+      assert.hasProperties(new ICAL.UtcOffset({
+        hours: 15,
+        minutes: 30
+      }), {
+        hours: 11, minutes: 30, factor: -1
+      });
+    });
+    test('hours underflow', function() {
+      assert.hasProperties(new ICAL.UtcOffset({
+        hours: 13,
+        minutes: 30,
+        factor: -1
+      }), {
+        hours: 13, minutes: 30, factor: 1
+      });
+    });
+    test('hours double underflow', function() {
+      assert.hasProperties(new ICAL.UtcOffset({
+        hours: 40,
+        minutes: 30,
+        factor: -1
+      }), {
+        hours: 13, minutes: 30, factor: 1
+      });
+    });
+    test('negative zero utc offset', function() {
+      assert.hasProperties(new ICAL.UtcOffset({
+        hours: 0,
+        minutes: 0,
+        factor: -1
+      }), {
+        hours: 0, minutes: 0, factor: -1
+      });
+
+    });
+  });
+
+  suite('#compare', function() {
+    test('greater', function() {
+      var a = new ICAL.UtcOffset({ hours: 5, minutes: 1 });
+      var b = new ICAL.UtcOffset({ hours: 5, minutes: 0 });
+      assert.equal(a.compare(b), 1);
+    });
+    test('equal', function() {
+      var a = new ICAL.UtcOffset({ hours: 15, minutes: 0 });
+      var b = new ICAL.UtcOffset({ hours: -12, minutes: 0 });
+      assert.equal(a.compare(b), 0);
+    });
+    test('equal zero', function() {
+      var a = new ICAL.UtcOffset({ hours: 0, minutes: 0, factor: -1 });
+      var b = new ICAL.UtcOffset({ hours: 0, minutes: 0 });
+      assert.equal(a.compare(b), 0);
+    });
+    test('less than', function() {
+      var a = new ICAL.UtcOffset({ hours: 5, minutes: 0 });
+      var b = new ICAL.UtcOffset({ hours: 5, minutes: 1 });
+      assert.equal(a.compare(b), -1);
+    });
+  });
+  
   suite('from/toSeconds', function() {
     test('static', function() {
       var subject = ICAL.UtcOffset.fromSeconds(3661);


### PR DESCRIPTION
Right now, UtcOffset has to be instantiated with three parameters; `hours`,`minutes` and `factor` (has to be 1 or -1, depending on which way the offset is).

If `hours` or `minutes` are negative, the output is weird (but apparently valid) output like `--100`.

It would be much easier if one could give it the complete input in either just hours or minutes, and calculating factor internally, ex:

```
new UtcOffset({ hours: -1 }); // -01:00
new UtcOffset({ minutes: -120 }); // -02:00
```
