### PR TITLE
Fix for..in loop with modified prototype

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -710,21 +710,22 @@ ICAL.design = (function() {
         var str = "";
         for (var k in data) {
           /* istanbul ignore else */
-          if (Object.prototype.hasOwnProperty.call(data, k)) {
-            var val = data[k];
-            if (k == "until") {
-              if (val.length > 10) {
-                val = icalValues['date-time'].toICAL(val);
-              } else {
-                val = icalValues.date.toICAL(val);
-              }
-            } else if (k == "wkst") {
-              val = ICAL.Recur.numericDayToIcalDay(val);
-            } else if (Array.isArray(val)) {
-              val = val.join(",");
-            }
-            str += k.toUpperCase() + "=" + val + ";";
+          if (!Object.prototype.hasOwnProperty.call(data, k)) {
+            continue;
           }
+          var val = data[k];
+          if (k == "until") {
+            if (val.length > 10) {
+              val = icalValues['date-time'].toICAL(val);
+            } else {
+              val = icalValues.date.toICAL(val);
+            }
+          } else if (k == "wkst") {
+            val = ICAL.Recur.numericDayToIcalDay(val);
+          } else if (Array.isArray(val)) {
+            val = val.join(",");
+          }
+          str += k.toUpperCase() + "=" + val + ";";
         }
         return str.substr(0, str.length - 1);
       },
@@ -3626,13 +3627,14 @@ ICAL.Binary = (function() {
                          "minutes", "seconds", "isNegative"];
       for (var key in propsToCopy) {
         /* istanbul ignore else */
-        if (propsToCopy.hasOwnProperty(key)) {
-          var prop = propsToCopy[key];
-          if (aData && prop in aData) {
-            this[prop] = aData[prop];
-          } else {
-            this[prop] = 0;
-          }
+        if (!propsToCopy.hasOwnProperty(key)) {
+          continue;
+        }
+        var prop = propsToCopy[key];
+        if (aData && prop in aData) {
+          this[prop] = aData[prop];
+        } else {
+          this[prop] = 0;
         }
       }
     },
@@ -4163,37 +4165,38 @@ ICAL.Binary = (function() {
         var props = aComponent.getAllProperties("rdate");
         for (var rdatekey in props) {
           /* istanbul ignore else */
-          if (props.hasOwnProperty(rdatekey)) {
-            var rdate = props[rdatekey];
-            var time = rdate.getFirstValue();
-            change = init_changes();
-
-            change.year = time.year;
-            change.month = time.month;
-            change.day = time.day;
-
-            if (time.isDate) {
-              change.hour = dtstart.hour;
-              change.minute = dtstart.minute;
-              change.second = dtstart.second;
-
-              if (dtstart.zone != ICAL.Timezone.utcTimezone) {
-                ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                                -change.prevUtcOffset);
-              }
-            } else {
-              change.hour = time.hour;
-              change.minute = time.minute;
-              change.second = time.second;
-
-              if (time.zone != ICAL.Timezone.utcTimezone) {
-                ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                                -change.prevUtcOffset);
-              }
-            }
-
-            changes.push(change);
+          if (!props.hasOwnProperty(rdatekey)) {
+            continue;
           }
+          var rdate = props[rdatekey];
+          var time = rdate.getFirstValue();
+          change = init_changes();
+
+          change.year = time.year;
+          change.month = time.month;
+          change.day = time.day;
+
+          if (time.isDate) {
+            change.hour = dtstart.hour;
+            change.minute = dtstart.minute;
+            change.second = dtstart.second;
+
+            if (dtstart.zone != ICAL.Timezone.utcTimezone) {
+              ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                              -change.prevUtcOffset);
+            }
+          } else {
+            change.hour = time.hour;
+            change.minute = time.minute;
+            change.second = time.second;
+
+            if (time.zone != ICAL.Timezone.utcTimezone) {
+              ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                              -change.prevUtcOffset);
+            }
+          }
+
+          changes.push(change);
         }
 
         var rrule = aComponent.getFirstProperty("rrule");
@@ -6239,13 +6242,14 @@ ICAL.TimezoneService = (function() {
 
       for (var k in this.parts) {
         /* istanbul ignore else */
-        if (this.parts.hasOwnProperty(k)) {
-          var kparts = this.parts[k];
-          if (Array.isArray(kparts) && kparts.length == 1) {
-            res[k.toLowerCase()] = kparts[0];
-          } else {
-            res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
-          }
+        if (!this.parts.hasOwnProperty(k)) {
+          continue;
+        }
+        var kparts = this.parts[k];
+        if (Array.isArray(kparts) && kparts.length == 1) {
+          res[k.toLowerCase()] = kparts[0];
+        } else {
+          res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
         }
       }
 
@@ -6751,36 +6755,37 @@ ICAL.RecurIterator = (function() {
         // Check every weekday in BYDAY with relative dow and pos.
         for (var i in this.by_data.BYDAY) {
           /* istanbul ignore else */
-          if (this.by_data.BYDAY.hasOwnProperty(i)) {
-            this.last = initLast.clone();
-            var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
-            var pos = bydayParts[0];
-            var dow = bydayParts[1];
-            var dayOfMonth = this.last.nthWeekDay(dow, pos);
+          if (!this.by_data.BYDAY.hasOwnProperty(i)) {
+            continue;
+          }
+          this.last = initLast.clone();
+          var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
+          var pos = bydayParts[0];
+          var dow = bydayParts[1];
+          var dayOfMonth = this.last.nthWeekDay(dow, pos);
 
-            // If |pos| >= 6, the byday is invalid for a monthly rule.
-            if (pos >= 6 || pos <= -6) {
-              throw new Error("Malformed values in BYDAY part");
-            }
+          // If |pos| >= 6, the byday is invalid for a monthly rule.
+          if (pos >= 6 || pos <= -6) {
+            throw new Error("Malformed values in BYDAY part");
+          }
 
-            // If a Byday with pos=+/-5 is not in the current month it
-            // must be searched in the next months.
-            if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-              // Skip if we have already found a "last" in this month.
-              if (tempLast && tempLast.month == initLast.month) {
-                continue;
-              }
-              while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-                this.increment_month();
-                daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
-                dayOfMonth = this.last.nthWeekDay(dow, pos);
-              }
+          // If a Byday with pos=+/-5 is not in the current month it
+          // must be searched in the next months.
+          if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+            // Skip if we have already found a "last" in this month.
+            if (tempLast && tempLast.month == initLast.month) {
+              continue;
             }
+            while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+              this.increment_month();
+              daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
+              dayOfMonth = this.last.nthWeekDay(dow, pos);
+            }
+          }
 
-            this.last.day = dayOfMonth;
-            if (!tempLast || this.last.compare(tempLast) < 0) {
-              tempLast = this.last.clone();
-            }
+          this.last.day = dayOfMonth;
+          if (!tempLast || this.last.compare(tempLast) < 0) {
+            tempLast = this.last.clone();
           }
         }
         this.last = tempLast.clone();
@@ -7485,53 +7490,57 @@ ICAL.RecurIterator = (function() {
       } else if (partCount == 1 && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
-            var t2 = this.dtstart.clone();
-            t2.year = aYear;
-            t2.month = this.by_data.BYMONTH[monthkey];
-            t2.isDate = true;
-            this.days.push(t2.dayOfYear());
+          if (!this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            continue;
           }
+          var t2 = this.dtstart.clone();
+          t2.year = aYear;
+          t2.month = this.by_data.BYMONTH[monthkey];
+          t2.isDate = true;
+          this.days.push(t2.dayOfYear());
         }
       } else if (partCount == 1 && "BYMONTHDAY" in parts) {
         for (var monthdaykey in this.by_data.BYMONTHDAY) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
-            var t3 = this.dtstart.clone();
-            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-            if (day_ < 0) {
-              var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
-              day_ = day_ + daysInMonth + 1;
-            }
-            t3.day = day_;
-            t3.year = aYear;
-            t3.isDate = true;
-            this.days.push(t3.dayOfYear());
+          if (!this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+            continue;
           }
+          var t3 = this.dtstart.clone();
+          var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+          if (day_ < 0) {
+            var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
+            day_ = day_ + daysInMonth + 1;
+          }
+          t3.day = day_;
+          t3.year = aYear;
+          t3.isDate = true;
+          this.days.push(t3.dayOfYear());
         }
       } else if (partCount == 2 &&
                  "BYMONTHDAY" in parts &&
                  "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
-            var month_ = this.by_data.BYMONTH[monthkey];
-            var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
-            for (var monthdaykey in this.by_data.BYMONTHDAY) {
-              /* istanbul ignore else */
-              if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
-                var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-                if (day_ < 0) {
-                  day_ = day_ + daysInMonth + 1;
-                }
-                t.day = day_;
-                t.month = month_;
-                t.year = aYear;
-                t.isDate = true;
-
-                this.days.push(t.dayOfYear());
-              }
+          if (!this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            continue;
+          }
+          var month_ = this.by_data.BYMONTH[monthkey];
+          var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
+          for (var monthdaykey in this.by_data.BYMONTHDAY) {
+            /* istanbul ignore else */
+            if (!this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+              continue;
             }
+            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+            if (day_ < 0) {
+              day_ = day_ + daysInMonth + 1;
+            }
+            t.day = day_;
+            t.month = month_;
+            t.year = aYear;
+            t.isDate = true;
+
+            this.days.push(t.dayOfYear());
           }
         }
       } else if (partCount == 1 && "BYWEEKNO" in parts) {
@@ -7545,67 +7554,69 @@ ICAL.RecurIterator = (function() {
       } else if (partCount == 2 && "BYDAY" in parts && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
-            var month = this.by_data.BYMONTH[monthkey];
-            var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
+          if (!this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            continue;
+          }
+          var month = this.by_data.BYMONTH[monthkey];
+          var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
 
-            t.year = aYear;
-            t.month = this.by_data.BYMONTH[monthkey];
-            t.day = 1;
-            t.isDate = true;
+          t.year = aYear;
+          t.month = this.by_data.BYMONTH[monthkey];
+          t.day = 1;
+          t.isDate = true;
 
-            var first_dow = t.dayOfWeek();
-            var doy_offset = t.dayOfYear() - 1;
+          var first_dow = t.dayOfWeek();
+          var doy_offset = t.dayOfYear() - 1;
 
-            t.day = daysInMonth;
-            var last_dow = t.dayOfWeek();
+          t.day = daysInMonth;
+          var last_dow = t.dayOfWeek();
 
-            if (this.has_by_data("BYSETPOS")) {
-              var set_pos_counter = 0;
-              var by_month_day = [];
-              for (var day = 1; day <= daysInMonth; day++) {
-                t.day = day;
-                if (this.is_day_in_byday(t)) {
-                  by_month_day.push(day);
-                }
+          if (this.has_by_data("BYSETPOS")) {
+            var set_pos_counter = 0;
+            var by_month_day = [];
+            for (var day = 1; day <= daysInMonth; day++) {
+              t.day = day;
+              if (this.is_day_in_byday(t)) {
+                by_month_day.push(day);
               }
+            }
 
-              for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
-                if (this.check_set_position(spIndex + 1) ||
-                    this.check_set_position(spIndex - by_month_day.length)) {
-                  this.days.push(doy_offset + by_month_day[spIndex]);
-                }
+            for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
+              if (this.check_set_position(spIndex + 1) ||
+                  this.check_set_position(spIndex - by_month_day.length)) {
+                this.days.push(doy_offset + by_month_day[spIndex]);
               }
-            } else {
-              for (var daycodedkey in this.by_data.BYDAY) {
-                /* istanbul ignore else */
-                if (this.by_data.BYDAY.hasOwnProperty(daycodedkey)) {
-                  var coded_day = this.by_data.BYDAY[daycodedkey];
-                  var bydayParts = this.ruleDayOfWeek(coded_day);
-                  var pos = bydayParts[0];
-                  var dow = bydayParts[1];
-                  var month_day;
+            }
+          } else {
+            for (var daycodedkey in this.by_data.BYDAY) {
+              /* istanbul ignore else */
+              if (!this.by_data.BYDAY.hasOwnProperty(daycodedkey)) {
+                continue;
+              }
+              var coded_day = this.by_data.BYDAY[daycodedkey];
+              var bydayParts = this.ruleDayOfWeek(coded_day);
+              var pos = bydayParts[0];
+              var dow = bydayParts[1];
+              var month_day;
 
-                  var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
-                  var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
+              var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
+              var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
 
-                  if (pos == 0) {
-                    for (var day = first_matching_day; day <= daysInMonth; day += 7) {
-                      this.days.push(doy_offset + day);
-                    }
-                  } else if (pos > 0) {
-                    month_day = first_matching_day + (pos - 1) * 7;
+              if (pos == 0) {
+                for (var day = first_matching_day; day <= daysInMonth; day += 7) {
+                  this.days.push(doy_offset + day);
+                }
+              } else if (pos > 0) {
+                month_day = first_matching_day + (pos - 1) * 7;
 
-                    if (month_day <= daysInMonth) {
-                      this.days.push(doy_offset + month_day);
-                    }
-                  } else {
-                    month_day = last_matching_day + (pos + 1) * 7;
+                if (month_day <= daysInMonth) {
+                  this.days.push(doy_offset + month_day);
+                }
+              } else {
+                month_day = last_matching_day + (pos + 1) * 7;
 
-                    if (month_day > 0) {
-                      this.days.push(doy_offset + month_day);
-                    }
-                  }
+                if (month_day > 0) {
+                  this.days.push(doy_offset + month_day);
                 }
               }
             }
@@ -7619,12 +7630,13 @@ ICAL.RecurIterator = (function() {
 
         for (var daykey in expandedDays) {
           /* istanbul ignore else */
-          if (expandedDays.hasOwnProperty(daykey)) {
-            var day = expandedDays[daykey];
-            var tt = ICAL.Time.fromDayOfYear(day, aYear);
-            if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-              this.days.push(day);
-            }
+          if (!expandedDays.hasOwnProperty(daykey)) {
+            continue;
+          }
+          var day = expandedDays[daykey];
+          var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+            this.days.push(day);
           }
         }
       } else if (partCount == 3 &&
@@ -7635,14 +7647,15 @@ ICAL.RecurIterator = (function() {
 
         for (var daykey in expandedDays) {
           /* istanbul ignore else */
-          if (expandedDays.hasOwnProperty(daykey)) {
-            var day = expandedDays[daykey];
-            var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          if (!expandedDays.hasOwnProperty(daykey)) {
+            continue;
+          }
+          var day = expandedDays[daykey];
+          var tt = ICAL.Time.fromDayOfYear(day, aYear);
 
-            if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
-                this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-              this.days.push(day);
-            }
+          if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
+              this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+            this.days.push(day);
           }
         }
       } else if (partCount == 2 && "BYDAY" in parts && "BYWEEKNO" in parts) {
@@ -7650,14 +7663,15 @@ ICAL.RecurIterator = (function() {
 
         for (var daykey in expandedDays) {
           /* istanbul ignore else */
-          if (expandedDays.hasOwnProperty(daykey)) {
-            var day = expandedDays[daykey];
-            var tt = ICAL.Time.fromDayOfYear(day, aYear);
-            var weekno = tt.weekNumber(this.rule.wkst);
+          if (!expandedDays.hasOwnProperty(daykey)) {
+            continue;
+          }
+          var day = expandedDays[daykey];
+          var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          var weekno = tt.weekNumber(this.rule.wkst);
 
-            if (this.by_data.BYWEEKNO.indexOf(weekno)) {
-              this.days.push(day);
-            }
+          if (this.by_data.BYWEEKNO.indexOf(weekno)) {
+            this.days.push(day);
           }
         }
       } else if (partCount == 3 &&
@@ -7694,40 +7708,41 @@ ICAL.RecurIterator = (function() {
 
       for (var daykey in this.by_data.BYDAY) {
         /* istanbul ignore else */
-        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
-          var day = this.by_data.BYDAY[daykey];
-          var parts = this.ruleDayOfWeek(day);
-          var pos = parts[0];
-          var dow = parts[1];
+        if (!this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          continue;
+        }
+        var day = this.by_data.BYDAY[daykey];
+        var parts = this.ruleDayOfWeek(day);
+        var pos = parts[0];
+        var dow = parts[1];
 
-          if (pos == 0) {
-            var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
+        if (pos == 0) {
+          var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
 
-            for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
-              days_list.push(doy);
-            }
-
-          } else if (pos > 0) {
-            var first;
-            if (dow >= start_dow) {
-              first = dow - start_dow + 1;
-            } else {
-              first = dow - start_dow + 8;
-            }
-
-            days_list.push(first + (pos - 1) * 7);
-          } else {
-            var last;
-            pos = -pos;
-
-            if (dow <= end_dow) {
-              last = end_year_day - end_dow + dow;
-            } else {
-              last = end_year_day - end_dow + dow - 7;
-            }
-
-            days_list.push(last - (pos - 1) * 7);
+          for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
+            days_list.push(doy);
           }
+
+        } else if (pos > 0) {
+          var first;
+          if (dow >= start_dow) {
+            first = dow - start_dow + 1;
+          } else {
+            first = dow - start_dow + 8;
+          }
+
+          days_list.push(first + (pos - 1) * 7);
+        } else {
+          var last;
+          pos = -pos;
+
+          if (dow <= end_dow) {
+            last = end_year_day - end_dow + dow;
+          } else {
+            last = end_year_day - end_dow + dow - 7;
+          }
+
+          days_list.push(last - (pos - 1) * 7);
         }
       }
       return days_list;
@@ -7736,17 +7751,18 @@ ICAL.RecurIterator = (function() {
     is_day_in_byday: function is_day_in_byday(tt) {
       for (var daykey in this.by_data.BYDAY) {
         /* istanbul ignore else */
-        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
-          var day = this.by_data.BYDAY[daykey];
-          var parts = this.ruleDayOfWeek(day);
-          var pos = parts[0];
-          var dow = parts[1];
-          var this_dow = tt.dayOfWeek();
+        if (!this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          continue;
+        }
+        var day = this.by_data.BYDAY[daykey];
+        var parts = this.ruleDayOfWeek(day);
+        var pos = parts[0];
+        var dow = parts[1];
+        var this_dow = tt.dayOfWeek();
 
-          if ((pos == 0 && dow == this_dow) ||
-              (tt.nthWeekDay(dow, pos) == tt.day)) {
-            return 1;
-          }
+        if ((pos == 0 && dow == this_dow) ||
+            (tt.nthWeekDay(dow, pos) == tt.day)) {
+          return 1;
         }
       }
 

--- a/build/ical.js
+++ b/build/ical.js
@@ -709,19 +709,22 @@ ICAL.design = (function() {
       toICAL: function(data) {
         var str = "";
         for (var k in data) {
-          var val = data[k];
-          if (k == "until") {
-            if (val.length > 10) {
-              val = icalValues['date-time'].toICAL(val);
-            } else {
-              val = icalValues.date.toICAL(val);
+          /* istanbul ignore else */
+          if (Object.prototype.hasOwnProperty.call(data, k)) {
+            var val = data[k];
+            if (k == "until") {
+              if (val.length > 10) {
+                val = icalValues['date-time'].toICAL(val);
+              } else {
+                val = icalValues.date.toICAL(val);
+              }
+            } else if (k == "wkst") {
+              val = ICAL.Recur.numericDayToIcalDay(val);
+            } else if (Array.isArray(val)) {
+              val = val.join(",");
             }
-          } else if (k == "wkst") {
-            val = ICAL.Recur.numericDayToIcalDay(val);
-          } else if (Array.isArray(val)) {
-            val = val.join(",");
+            str += k.toUpperCase() + "=" + val + ";";
           }
-          str += k.toUpperCase() + "=" + val + ";";
         }
         return str.substr(0, str.length - 1);
       },
@@ -2936,7 +2939,10 @@ ICAL.UtcOffset = (function() {
     fromData: function(aData) {
       if (aData) {
         for (var key in aData) {
-          this[key] = aData[key];
+          /* istanbul ignore else */
+          if (aData.hasOwnProperty(key)) {
+            this[key] = aData[key];
+          }
         }
       }
       this._normalize();
@@ -3619,11 +3625,14 @@ ICAL.Binary = (function() {
       var propsToCopy = ["weeks", "days", "hours",
                          "minutes", "seconds", "isNegative"];
       for (var key in propsToCopy) {
-        var prop = propsToCopy[key];
-        if (aData && prop in aData) {
-          this[prop] = aData[prop];
-        } else {
-          this[prop] = 0;
+        /* istanbul ignore else */
+        if (propsToCopy.hasOwnProperty(key)) {
+          var prop = propsToCopy[key];
+          if (aData && prop in aData) {
+            this[prop] = aData[prop];
+          } else {
+            this[prop] = 0;
+          }
         }
       }
     },
@@ -3956,9 +3965,12 @@ ICAL.Binary = (function() {
 
         // Copy remaining passed properties
         for (var key in OPTIONS) {
-          var prop = OPTIONS[key];
-          if (aData && prop in aData) {
-            this[prop] = aData[prop];
+          /* istanbul ignore else */
+          if (OPTIONS.hasOwnProperty(key)) {
+            var prop = OPTIONS[key];
+            if (aData && prop in aData) {
+              this[prop] = aData[prop];
+            }
           }
         }
       }
@@ -4150,35 +4162,38 @@ ICAL.Binary = (function() {
       } else {
         var props = aComponent.getAllProperties("rdate");
         for (var rdatekey in props) {
-          var rdate = props[rdatekey];
-          var time = rdate.getFirstValue();
-          change = init_changes();
+          /* istanbul ignore else */
+          if (props.hasOwnProperty(rdatekey)) {
+            var rdate = props[rdatekey];
+            var time = rdate.getFirstValue();
+            change = init_changes();
 
-          change.year = time.year;
-          change.month = time.month;
-          change.day = time.day;
+            change.year = time.year;
+            change.month = time.month;
+            change.day = time.day;
 
-          if (time.isDate) {
-            change.hour = dtstart.hour;
-            change.minute = dtstart.minute;
-            change.second = dtstart.second;
+            if (time.isDate) {
+              change.hour = dtstart.hour;
+              change.minute = dtstart.minute;
+              change.second = dtstart.second;
 
-            if (dtstart.zone != ICAL.Timezone.utcTimezone) {
-              ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                              -change.prevUtcOffset);
+              if (dtstart.zone != ICAL.Timezone.utcTimezone) {
+                ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                                -change.prevUtcOffset);
+              }
+            } else {
+              change.hour = time.hour;
+              change.minute = time.minute;
+              change.second = time.second;
+
+              if (time.zone != ICAL.Timezone.utcTimezone) {
+                ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                                -change.prevUtcOffset);
+              }
             }
-          } else {
-            change.hour = time.hour;
-            change.minute = time.minute;
-            change.second = time.second;
 
-            if (time.zone != ICAL.Timezone.utcTimezone) {
-              ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                              -change.prevUtcOffset);
-            }
+            changes.push(change);
           }
-
-          changes.push(change);
         }
 
         var rrule = aComponent.getFirstProperty("rrule");
@@ -4621,9 +4636,12 @@ ICAL.TimezoneService = (function() {
     fromData: function fromData(aData, aZone) {
       if (aData) {
         for (var key in aData) {
-          // ical type cannot be set
-          if (key === 'icaltype') continue;
-          this[key] = aData[key];
+          /* istanbul ignore else */
+          if (Object.prototype.hasOwnProperty.call(aData, key)) {
+            // ical type cannot be set
+            if (key === 'icaltype') continue;
+            this[key] = aData[key];
+          }
         }
       }
 
@@ -5942,7 +5960,10 @@ ICAL.TimezoneService = (function() {
 
   var REVERSE_DOW_MAP = {};
   for (var key in DOW_MAP) {
-    REVERSE_DOW_MAP[DOW_MAP[key]] = key;
+    /* istanbul ignore else */
+    if (DOW_MAP.hasOwnProperty(key)) {
+      REVERSE_DOW_MAP[DOW_MAP[key]] = key;
+    }
   }
 
   var COPY_PARTS = ["BYSECOND", "BYMINUTE", "BYHOUR", "BYDAY",
@@ -6217,11 +6238,14 @@ ICAL.TimezoneService = (function() {
       }
 
       for (var k in this.parts) {
-        var kparts = this.parts[k];
-        if (Array.isArray(kparts) && kparts.length == 1) {
-          res[k.toLowerCase()] = kparts[0];
-        } else {
-          res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
+        /* istanbul ignore else */
+        if (this.parts.hasOwnProperty(k)) {
+          var kparts = this.parts[k];
+          if (Array.isArray(kparts) && kparts.length == 1) {
+            res[k.toLowerCase()] = kparts[0];
+          } else {
+            res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
+          }
         }
       }
 
@@ -6248,7 +6272,10 @@ ICAL.TimezoneService = (function() {
         str += ";INTERVAL=" + this.interval;
       }
       for (var k in this.parts) {
-        str += ";" + k + "=" + this.parts[k];
+        /* istanbul ignore else */
+        if (this.parts.hasOwnProperty(k)) {
+          str += ";" + k + "=" + this.parts[k];
+        }
       }
       if (this.until) {
         str += ';UNTIL=' + this.until.toString();
@@ -6723,34 +6750,37 @@ ICAL.RecurIterator = (function() {
 
         // Check every weekday in BYDAY with relative dow and pos.
         for (var i in this.by_data.BYDAY) {
-          this.last = initLast.clone();
-          var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
-          var pos = bydayParts[0];
-          var dow = bydayParts[1];
-          var dayOfMonth = this.last.nthWeekDay(dow, pos);
+          /* istanbul ignore else */
+          if (this.by_data.BYDAY.hasOwnProperty(i)) {
+            this.last = initLast.clone();
+            var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
+            var pos = bydayParts[0];
+            var dow = bydayParts[1];
+            var dayOfMonth = this.last.nthWeekDay(dow, pos);
 
-          // If |pos| >= 6, the byday is invalid for a monthly rule.
-          if (pos >= 6 || pos <= -6) {
-            throw new Error("Malformed values in BYDAY part");
-          }
-
-          // If a Byday with pos=+/-5 is not in the current month it
-          // must be searched in the next months.
-          if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-            // Skip if we have already found a "last" in this month.
-            if (tempLast && tempLast.month == initLast.month) {
-              continue;
+            // If |pos| >= 6, the byday is invalid for a monthly rule.
+            if (pos >= 6 || pos <= -6) {
+              throw new Error("Malformed values in BYDAY part");
             }
-            while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-              this.increment_month();
-              daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
-              dayOfMonth = this.last.nthWeekDay(dow, pos);
-            }
-          }
 
-          this.last.day = dayOfMonth;
-          if (!tempLast || this.last.compare(tempLast) < 0) {
-            tempLast = this.last.clone();
+            // If a Byday with pos=+/-5 is not in the current month it
+            // must be searched in the next months.
+            if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+              // Skip if we have already found a "last" in this month.
+              if (tempLast && tempLast.month == initLast.month) {
+                continue;
+              }
+              while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+                this.increment_month();
+                daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
+                dayOfMonth = this.last.nthWeekDay(dow, pos);
+              }
+            }
+
+            this.last.day = dayOfMonth;
+            if (!tempLast || this.last.compare(tempLast) < 0) {
+              tempLast = this.last.clone();
+            }
           }
         }
         this.last = tempLast.clone();
@@ -7403,9 +7433,12 @@ ICAL.RecurIterator = (function() {
       var parts = {};
       var rules = ["BYDAY", "BYWEEKNO", "BYMONTHDAY", "BYMONTH", "BYYEARDAY"];
       for (var p in rules) {
-        var part = rules[p];
-        if (part in this.rule.parts) {
-          parts[part] = this.rule.parts[part];
+        /* istanbul ignore else */
+        if (rules.hasOwnProperty(p)) {
+          var part = rules[p];
+          if (part in this.rule.parts) {
+            parts[part] = this.rule.parts[part];
+          }
         }
       }
 
@@ -7451,42 +7484,54 @@ ICAL.RecurIterator = (function() {
         this.days.push(t1.dayOfYear());
       } else if (partCount == 1 && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
-          var t2 = this.dtstart.clone();
-          t2.year = aYear;
-          t2.month = this.by_data.BYMONTH[monthkey];
-          t2.isDate = true;
-          this.days.push(t2.dayOfYear());
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            var t2 = this.dtstart.clone();
+            t2.year = aYear;
+            t2.month = this.by_data.BYMONTH[monthkey];
+            t2.isDate = true;
+            this.days.push(t2.dayOfYear());
+          }
         }
       } else if (partCount == 1 && "BYMONTHDAY" in parts) {
         for (var monthdaykey in this.by_data.BYMONTHDAY) {
-          var t3 = this.dtstart.clone();
-          var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-          if (day_ < 0) {
-            var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
-            day_ = day_ + daysInMonth + 1;
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+            var t3 = this.dtstart.clone();
+            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+            if (day_ < 0) {
+              var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
+              day_ = day_ + daysInMonth + 1;
+            }
+            t3.day = day_;
+            t3.year = aYear;
+            t3.isDate = true;
+            this.days.push(t3.dayOfYear());
           }
-          t3.day = day_;
-          t3.year = aYear;
-          t3.isDate = true;
-          this.days.push(t3.dayOfYear());
         }
       } else if (partCount == 2 &&
                  "BYMONTHDAY" in parts &&
                  "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
-          var month_ = this.by_data.BYMONTH[monthkey];
-          var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
-          for (var monthdaykey in this.by_data.BYMONTHDAY) {
-            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-            if (day_ < 0) {
-              day_ = day_ + daysInMonth + 1;
-            }
-            t.day = day_;
-            t.month = month_;
-            t.year = aYear;
-            t.isDate = true;
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            var month_ = this.by_data.BYMONTH[monthkey];
+            var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
+            for (var monthdaykey in this.by_data.BYMONTHDAY) {
+              /* istanbul ignore else */
+              if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+                var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+                if (day_ < 0) {
+                  day_ = day_ + daysInMonth + 1;
+                }
+                t.day = day_;
+                t.month = month_;
+                t.year = aYear;
+                t.isDate = true;
 
-            this.days.push(t.dayOfYear());
+                this.days.push(t.dayOfYear());
+              }
+            }
           }
         }
       } else if (partCount == 1 && "BYWEEKNO" in parts) {
@@ -7499,62 +7544,68 @@ ICAL.RecurIterator = (function() {
         this.days = this.days.concat(this.expand_by_day(aYear));
       } else if (partCount == 2 && "BYDAY" in parts && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
-          var month = this.by_data.BYMONTH[monthkey];
-          var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            var month = this.by_data.BYMONTH[monthkey];
+            var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
 
-          t.year = aYear;
-          t.month = this.by_data.BYMONTH[monthkey];
-          t.day = 1;
-          t.isDate = true;
+            t.year = aYear;
+            t.month = this.by_data.BYMONTH[monthkey];
+            t.day = 1;
+            t.isDate = true;
 
-          var first_dow = t.dayOfWeek();
-          var doy_offset = t.dayOfYear() - 1;
+            var first_dow = t.dayOfWeek();
+            var doy_offset = t.dayOfYear() - 1;
 
-          t.day = daysInMonth;
-          var last_dow = t.dayOfWeek();
+            t.day = daysInMonth;
+            var last_dow = t.dayOfWeek();
 
-          if (this.has_by_data("BYSETPOS")) {
-            var set_pos_counter = 0;
-            var by_month_day = [];
-            for (var day = 1; day <= daysInMonth; day++) {
-              t.day = day;
-              if (this.is_day_in_byday(t)) {
-                by_month_day.push(day);
-              }
-            }
-
-            for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
-              if (this.check_set_position(spIndex + 1) ||
-                  this.check_set_position(spIndex - by_month_day.length)) {
-                this.days.push(doy_offset + by_month_day[spIndex]);
-              }
-            }
-          } else {
-            for (var daycodedkey in this.by_data.BYDAY) {
-              var coded_day = this.by_data.BYDAY[daycodedkey];
-              var bydayParts = this.ruleDayOfWeek(coded_day);
-              var pos = bydayParts[0];
-              var dow = bydayParts[1];
-              var month_day;
-
-              var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
-              var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
-
-              if (pos == 0) {
-                for (var day = first_matching_day; day <= daysInMonth; day += 7) {
-                  this.days.push(doy_offset + day);
+            if (this.has_by_data("BYSETPOS")) {
+              var set_pos_counter = 0;
+              var by_month_day = [];
+              for (var day = 1; day <= daysInMonth; day++) {
+                t.day = day;
+                if (this.is_day_in_byday(t)) {
+                  by_month_day.push(day);
                 }
-              } else if (pos > 0) {
-                month_day = first_matching_day + (pos - 1) * 7;
+              }
 
-                if (month_day <= daysInMonth) {
-                  this.days.push(doy_offset + month_day);
+              for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
+                if (this.check_set_position(spIndex + 1) ||
+                    this.check_set_position(spIndex - by_month_day.length)) {
+                  this.days.push(doy_offset + by_month_day[spIndex]);
                 }
-              } else {
-                month_day = last_matching_day + (pos + 1) * 7;
+              }
+            } else {
+              for (var daycodedkey in this.by_data.BYDAY) {
+                /* istanbul ignore else */
+                if (this.by_data.BYDAY.hasOwnProperty(daycodedkey)) {
+                  var coded_day = this.by_data.BYDAY[daycodedkey];
+                  var bydayParts = this.ruleDayOfWeek(coded_day);
+                  var pos = bydayParts[0];
+                  var dow = bydayParts[1];
+                  var month_day;
 
-                if (month_day > 0) {
-                  this.days.push(doy_offset + month_day);
+                  var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
+                  var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
+
+                  if (pos == 0) {
+                    for (var day = first_matching_day; day <= daysInMonth; day += 7) {
+                      this.days.push(doy_offset + day);
+                    }
+                  } else if (pos > 0) {
+                    month_day = first_matching_day + (pos - 1) * 7;
+
+                    if (month_day <= daysInMonth) {
+                      this.days.push(doy_offset + month_day);
+                    }
+                  } else {
+                    month_day = last_matching_day + (pos + 1) * 7;
+
+                    if (month_day > 0) {
+                      this.days.push(doy_offset + month_day);
+                    }
+                  }
                 }
               }
             }
@@ -7567,10 +7618,13 @@ ICAL.RecurIterator = (function() {
         var expandedDays = this.expand_by_day(aYear);
 
         for (var daykey in expandedDays) {
-          var day = expandedDays[daykey];
-          var tt = ICAL.Time.fromDayOfYear(day, aYear);
-          if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-            this.days.push(day);
+          /* istanbul ignore else */
+          if (expandedDays.hasOwnProperty(daykey)) {
+            var day = expandedDays[daykey];
+            var tt = ICAL.Time.fromDayOfYear(day, aYear);
+            if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+              this.days.push(day);
+            }
           }
         }
       } else if (partCount == 3 &&
@@ -7580,24 +7634,30 @@ ICAL.RecurIterator = (function() {
         var expandedDays = this.expand_by_day(aYear);
 
         for (var daykey in expandedDays) {
-          var day = expandedDays[daykey];
-          var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          /* istanbul ignore else */
+          if (expandedDays.hasOwnProperty(daykey)) {
+            var day = expandedDays[daykey];
+            var tt = ICAL.Time.fromDayOfYear(day, aYear);
 
-          if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
-              this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-            this.days.push(day);
+            if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
+                this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+              this.days.push(day);
+            }
           }
         }
       } else if (partCount == 2 && "BYDAY" in parts && "BYWEEKNO" in parts) {
         var expandedDays = this.expand_by_day(aYear);
 
         for (var daykey in expandedDays) {
-          var day = expandedDays[daykey];
-          var tt = ICAL.Time.fromDayOfYear(day, aYear);
-          var weekno = tt.weekNumber(this.rule.wkst);
+          /* istanbul ignore else */
+          if (expandedDays.hasOwnProperty(daykey)) {
+            var day = expandedDays[daykey];
+            var tt = ICAL.Time.fromDayOfYear(day, aYear);
+            var weekno = tt.weekNumber(this.rule.wkst);
 
-          if (this.by_data.BYWEEKNO.indexOf(weekno)) {
-            this.days.push(day);
+            if (this.by_data.BYWEEKNO.indexOf(weekno)) {
+              this.days.push(day);
+            }
           }
         }
       } else if (partCount == 3 &&
@@ -7633,38 +7693,41 @@ ICAL.RecurIterator = (function() {
       var end_year_day = tmp.dayOfYear();
 
       for (var daykey in this.by_data.BYDAY) {
-        var day = this.by_data.BYDAY[daykey];
-        var parts = this.ruleDayOfWeek(day);
-        var pos = parts[0];
-        var dow = parts[1];
+        /* istanbul ignore else */
+        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          var day = this.by_data.BYDAY[daykey];
+          var parts = this.ruleDayOfWeek(day);
+          var pos = parts[0];
+          var dow = parts[1];
 
-        if (pos == 0) {
-          var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
+          if (pos == 0) {
+            var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
 
-          for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
-            days_list.push(doy);
-          }
+            for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
+              days_list.push(doy);
+            }
 
-        } else if (pos > 0) {
-          var first;
-          if (dow >= start_dow) {
-            first = dow - start_dow + 1;
+          } else if (pos > 0) {
+            var first;
+            if (dow >= start_dow) {
+              first = dow - start_dow + 1;
+            } else {
+              first = dow - start_dow + 8;
+            }
+
+            days_list.push(first + (pos - 1) * 7);
           } else {
-            first = dow - start_dow + 8;
+            var last;
+            pos = -pos;
+
+            if (dow <= end_dow) {
+              last = end_year_day - end_dow + dow;
+            } else {
+              last = end_year_day - end_dow + dow - 7;
+            }
+
+            days_list.push(last - (pos - 1) * 7);
           }
-
-          days_list.push(first + (pos - 1) * 7);
-        } else {
-          var last;
-          pos = -pos;
-
-          if (dow <= end_dow) {
-            last = end_year_day - end_dow + dow;
-          } else {
-            last = end_year_day - end_dow + dow - 7;
-          }
-
-          days_list.push(last - (pos - 1) * 7);
         }
       }
       return days_list;
@@ -7672,15 +7735,18 @@ ICAL.RecurIterator = (function() {
 
     is_day_in_byday: function is_day_in_byday(tt) {
       for (var daykey in this.by_data.BYDAY) {
-        var day = this.by_data.BYDAY[daykey];
-        var parts = this.ruleDayOfWeek(day);
-        var pos = parts[0];
-        var dow = parts[1];
-        var this_dow = tt.dayOfWeek();
+        /* istanbul ignore else */
+        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          var day = this.by_data.BYDAY[daykey];
+          var parts = this.ruleDayOfWeek(day);
+          var pos = parts[0];
+          var dow = parts[1];
+          var this_dow = tt.dayOfWeek();
 
-        if ((pos == 0 && dow == this_dow) ||
-            (tt.nthWeekDay(dow, pos) == tt.day)) {
-          return 1;
+          if ((pos == 0 && dow == this_dow) ||
+              (tt.nthWeekDay(dow, pos) == tt.day)) {
+            return 1;
+          }
         }
       }
 
@@ -7734,9 +7800,12 @@ ICAL.RecurIterator = (function() {
         var ruleType = this.by_data[aRuleType];
 
         for (var bydatakey in ruleType) {
-          if (ruleType[bydatakey] == v) {
-            pass = true;
-            break;
+          /* istanbul ignore else */
+          if (ruleType.hasOwnProperty(bydatakey)) {
+            if (ruleType[bydatakey] == v) {
+              pass = true;
+              break;
+            }
           }
         }
       } else {

--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -428,19 +428,22 @@ ICAL.design = (function() {
       toICAL: function(data) {
         var str = "";
         for (var k in data) {
-          var val = data[k];
-          if (k == "until") {
-            if (val.length > 10) {
-              val = icalValues['date-time'].toICAL(val);
-            } else {
-              val = icalValues.date.toICAL(val);
+          /* istanbul ignore else */
+          if (Object.prototype.hasOwnProperty.call(data, k)) {
+            var val = data[k];
+            if (k == "until") {
+              if (val.length > 10) {
+                val = icalValues['date-time'].toICAL(val);
+              } else {
+                val = icalValues.date.toICAL(val);
+              }
+            } else if (k == "wkst") {
+              val = ICAL.Recur.numericDayToIcalDay(val);
+            } else if (Array.isArray(val)) {
+              val = val.join(",");
             }
-          } else if (k == "wkst") {
-            val = ICAL.Recur.numericDayToIcalDay(val);
-          } else if (Array.isArray(val)) {
-            val = val.join(",");
+            str += k.toUpperCase() + "=" + val + ";";
           }
-          str += k.toUpperCase() + "=" + val + ";";
         }
         return str.substr(0, str.length - 1);
       },

--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -429,21 +429,22 @@ ICAL.design = (function() {
         var str = "";
         for (var k in data) {
           /* istanbul ignore else */
-          if (Object.prototype.hasOwnProperty.call(data, k)) {
-            var val = data[k];
-            if (k == "until") {
-              if (val.length > 10) {
-                val = icalValues['date-time'].toICAL(val);
-              } else {
-                val = icalValues.date.toICAL(val);
-              }
-            } else if (k == "wkst") {
-              val = ICAL.Recur.numericDayToIcalDay(val);
-            } else if (Array.isArray(val)) {
-              val = val.join(",");
-            }
-            str += k.toUpperCase() + "=" + val + ";";
+          if (!Object.prototype.hasOwnProperty.call(data, k)) {
+            continue;
           }
+          var val = data[k];
+          if (k == "until") {
+            if (val.length > 10) {
+              val = icalValues['date-time'].toICAL(val);
+            } else {
+              val = icalValues.date.toICAL(val);
+            }
+          } else if (k == "wkst") {
+            val = ICAL.Recur.numericDayToIcalDay(val);
+          } else if (Array.isArray(val)) {
+            val = val.join(",");
+          }
+          str += k.toUpperCase() + "=" + val + ";";
         }
         return str.substr(0, str.length - 1);
       },

--- a/lib/ical/duration.js
+++ b/lib/ical/duration.js
@@ -160,13 +160,14 @@
                          "minutes", "seconds", "isNegative"];
       for (var key in propsToCopy) {
         /* istanbul ignore else */
-        if (propsToCopy.hasOwnProperty(key)) {
-          var prop = propsToCopy[key];
-          if (aData && prop in aData) {
-            this[prop] = aData[prop];
-          } else {
-            this[prop] = 0;
-          }
+        if (!propsToCopy.hasOwnProperty(key)) {
+          continue;
+        }
+        var prop = propsToCopy[key];
+        if (aData && prop in aData) {
+          this[prop] = aData[prop];
+        } else {
+          this[prop] = 0;
         }
       }
     },

--- a/lib/ical/duration.js
+++ b/lib/ical/duration.js
@@ -159,11 +159,14 @@
       var propsToCopy = ["weeks", "days", "hours",
                          "minutes", "seconds", "isNegative"];
       for (var key in propsToCopy) {
-        var prop = propsToCopy[key];
-        if (aData && prop in aData) {
-          this[prop] = aData[prop];
-        } else {
-          this[prop] = 0;
+        /* istanbul ignore else */
+        if (propsToCopy.hasOwnProperty(key)) {
+          var prop = propsToCopy[key];
+          if (aData && prop in aData) {
+            this[prop] = aData[prop];
+          } else {
+            this[prop] = 0;
+          }
         }
       }
     },

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -300,13 +300,14 @@
 
       for (var k in this.parts) {
         /* istanbul ignore else */
-        if (this.parts.hasOwnProperty(k)) {
-          var kparts = this.parts[k];
-          if (Array.isArray(kparts) && kparts.length == 1) {
-            res[k.toLowerCase()] = kparts[0];
-          } else {
-            res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
-          }
+        if (!this.parts.hasOwnProperty(k)) {
+          continue;
+        }
+        var kparts = this.parts[k];
+        if (Array.isArray(kparts) && kparts.length == 1) {
+          res[k.toLowerCase()] = kparts[0];
+        } else {
+          res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
         }
       }
 

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -21,7 +21,10 @@
 
   var REVERSE_DOW_MAP = {};
   for (var key in DOW_MAP) {
-    REVERSE_DOW_MAP[DOW_MAP[key]] = key;
+    /* istanbul ignore else */
+    if (DOW_MAP.hasOwnProperty(key)) {
+      REVERSE_DOW_MAP[DOW_MAP[key]] = key;
+    }
   }
 
   var COPY_PARTS = ["BYSECOND", "BYMINUTE", "BYHOUR", "BYDAY",
@@ -296,11 +299,14 @@
       }
 
       for (var k in this.parts) {
-        var kparts = this.parts[k];
-        if (Array.isArray(kparts) && kparts.length == 1) {
-          res[k.toLowerCase()] = kparts[0];
-        } else {
-          res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
+        /* istanbul ignore else */
+        if (this.parts.hasOwnProperty(k)) {
+          var kparts = this.parts[k];
+          if (Array.isArray(kparts) && kparts.length == 1) {
+            res[k.toLowerCase()] = kparts[0];
+          } else {
+            res[k.toLowerCase()] = ICAL.helpers.clone(this.parts[k]);
+          }
         }
       }
 
@@ -327,7 +333,10 @@
         str += ";INTERVAL=" + this.interval;
       }
       for (var k in this.parts) {
-        str += ";" + k + "=" + this.parts[k];
+        /* istanbul ignore else */
+        if (this.parts.hasOwnProperty(k)) {
+          str += ";" + k + "=" + this.parts[k];
+        }
       }
       if (this.until) {
         str += ';UNTIL=' + this.until.toString();

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -250,34 +250,37 @@ ICAL.RecurIterator = (function() {
 
         // Check every weekday in BYDAY with relative dow and pos.
         for (var i in this.by_data.BYDAY) {
-          this.last = initLast.clone();
-          var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
-          var pos = bydayParts[0];
-          var dow = bydayParts[1];
-          var dayOfMonth = this.last.nthWeekDay(dow, pos);
+          /* istanbul ignore else */
+          if (this.by_data.BYDAY.hasOwnProperty(i)) {
+            this.last = initLast.clone();
+            var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
+            var pos = bydayParts[0];
+            var dow = bydayParts[1];
+            var dayOfMonth = this.last.nthWeekDay(dow, pos);
 
-          // If |pos| >= 6, the byday is invalid for a monthly rule.
-          if (pos >= 6 || pos <= -6) {
-            throw new Error("Malformed values in BYDAY part");
-          }
-
-          // If a Byday with pos=+/-5 is not in the current month it
-          // must be searched in the next months.
-          if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-            // Skip if we have already found a "last" in this month.
-            if (tempLast && tempLast.month == initLast.month) {
-              continue;
+            // If |pos| >= 6, the byday is invalid for a monthly rule.
+            if (pos >= 6 || pos <= -6) {
+              throw new Error("Malformed values in BYDAY part");
             }
-            while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-              this.increment_month();
-              daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
-              dayOfMonth = this.last.nthWeekDay(dow, pos);
-            }
-          }
 
-          this.last.day = dayOfMonth;
-          if (!tempLast || this.last.compare(tempLast) < 0) {
-            tempLast = this.last.clone();
+            // If a Byday with pos=+/-5 is not in the current month it
+            // must be searched in the next months.
+            if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+              // Skip if we have already found a "last" in this month.
+              if (tempLast && tempLast.month == initLast.month) {
+                continue;
+              }
+              while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+                this.increment_month();
+                daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
+                dayOfMonth = this.last.nthWeekDay(dow, pos);
+              }
+            }
+
+            this.last.day = dayOfMonth;
+            if (!tempLast || this.last.compare(tempLast) < 0) {
+              tempLast = this.last.clone();
+            }
           }
         }
         this.last = tempLast.clone();
@@ -930,9 +933,12 @@ ICAL.RecurIterator = (function() {
       var parts = {};
       var rules = ["BYDAY", "BYWEEKNO", "BYMONTHDAY", "BYMONTH", "BYYEARDAY"];
       for (var p in rules) {
-        var part = rules[p];
-        if (part in this.rule.parts) {
-          parts[part] = this.rule.parts[part];
+        /* istanbul ignore else */
+        if (rules.hasOwnProperty(p)) {
+          var part = rules[p];
+          if (part in this.rule.parts) {
+            parts[part] = this.rule.parts[part];
+          }
         }
       }
 
@@ -978,42 +984,54 @@ ICAL.RecurIterator = (function() {
         this.days.push(t1.dayOfYear());
       } else if (partCount == 1 && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
-          var t2 = this.dtstart.clone();
-          t2.year = aYear;
-          t2.month = this.by_data.BYMONTH[monthkey];
-          t2.isDate = true;
-          this.days.push(t2.dayOfYear());
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            var t2 = this.dtstart.clone();
+            t2.year = aYear;
+            t2.month = this.by_data.BYMONTH[monthkey];
+            t2.isDate = true;
+            this.days.push(t2.dayOfYear());
+          }
         }
       } else if (partCount == 1 && "BYMONTHDAY" in parts) {
         for (var monthdaykey in this.by_data.BYMONTHDAY) {
-          var t3 = this.dtstart.clone();
-          var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-          if (day_ < 0) {
-            var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
-            day_ = day_ + daysInMonth + 1;
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+            var t3 = this.dtstart.clone();
+            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+            if (day_ < 0) {
+              var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
+              day_ = day_ + daysInMonth + 1;
+            }
+            t3.day = day_;
+            t3.year = aYear;
+            t3.isDate = true;
+            this.days.push(t3.dayOfYear());
           }
-          t3.day = day_;
-          t3.year = aYear;
-          t3.isDate = true;
-          this.days.push(t3.dayOfYear());
         }
       } else if (partCount == 2 &&
                  "BYMONTHDAY" in parts &&
                  "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
-          var month_ = this.by_data.BYMONTH[monthkey];
-          var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
-          for (var monthdaykey in this.by_data.BYMONTHDAY) {
-            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-            if (day_ < 0) {
-              day_ = day_ + daysInMonth + 1;
-            }
-            t.day = day_;
-            t.month = month_;
-            t.year = aYear;
-            t.isDate = true;
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            var month_ = this.by_data.BYMONTH[monthkey];
+            var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
+            for (var monthdaykey in this.by_data.BYMONTHDAY) {
+              /* istanbul ignore else */
+              if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+                var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+                if (day_ < 0) {
+                  day_ = day_ + daysInMonth + 1;
+                }
+                t.day = day_;
+                t.month = month_;
+                t.year = aYear;
+                t.isDate = true;
 
-            this.days.push(t.dayOfYear());
+                this.days.push(t.dayOfYear());
+              }
+            }
           }
         }
       } else if (partCount == 1 && "BYWEEKNO" in parts) {
@@ -1026,62 +1044,68 @@ ICAL.RecurIterator = (function() {
         this.days = this.days.concat(this.expand_by_day(aYear));
       } else if (partCount == 2 && "BYDAY" in parts && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
-          var month = this.by_data.BYMONTH[monthkey];
-          var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
+          /* istanbul ignore else */
+          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            var month = this.by_data.BYMONTH[monthkey];
+            var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
 
-          t.year = aYear;
-          t.month = this.by_data.BYMONTH[monthkey];
-          t.day = 1;
-          t.isDate = true;
+            t.year = aYear;
+            t.month = this.by_data.BYMONTH[monthkey];
+            t.day = 1;
+            t.isDate = true;
 
-          var first_dow = t.dayOfWeek();
-          var doy_offset = t.dayOfYear() - 1;
+            var first_dow = t.dayOfWeek();
+            var doy_offset = t.dayOfYear() - 1;
 
-          t.day = daysInMonth;
-          var last_dow = t.dayOfWeek();
+            t.day = daysInMonth;
+            var last_dow = t.dayOfWeek();
 
-          if (this.has_by_data("BYSETPOS")) {
-            var set_pos_counter = 0;
-            var by_month_day = [];
-            for (var day = 1; day <= daysInMonth; day++) {
-              t.day = day;
-              if (this.is_day_in_byday(t)) {
-                by_month_day.push(day);
-              }
-            }
-
-            for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
-              if (this.check_set_position(spIndex + 1) ||
-                  this.check_set_position(spIndex - by_month_day.length)) {
-                this.days.push(doy_offset + by_month_day[spIndex]);
-              }
-            }
-          } else {
-            for (var daycodedkey in this.by_data.BYDAY) {
-              var coded_day = this.by_data.BYDAY[daycodedkey];
-              var bydayParts = this.ruleDayOfWeek(coded_day);
-              var pos = bydayParts[0];
-              var dow = bydayParts[1];
-              var month_day;
-
-              var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
-              var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
-
-              if (pos == 0) {
-                for (var day = first_matching_day; day <= daysInMonth; day += 7) {
-                  this.days.push(doy_offset + day);
+            if (this.has_by_data("BYSETPOS")) {
+              var set_pos_counter = 0;
+              var by_month_day = [];
+              for (var day = 1; day <= daysInMonth; day++) {
+                t.day = day;
+                if (this.is_day_in_byday(t)) {
+                  by_month_day.push(day);
                 }
-              } else if (pos > 0) {
-                month_day = first_matching_day + (pos - 1) * 7;
+              }
 
-                if (month_day <= daysInMonth) {
-                  this.days.push(doy_offset + month_day);
+              for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
+                if (this.check_set_position(spIndex + 1) ||
+                    this.check_set_position(spIndex - by_month_day.length)) {
+                  this.days.push(doy_offset + by_month_day[spIndex]);
                 }
-              } else {
-                month_day = last_matching_day + (pos + 1) * 7;
+              }
+            } else {
+              for (var daycodedkey in this.by_data.BYDAY) {
+                /* istanbul ignore else */
+                if (this.by_data.BYDAY.hasOwnProperty(daycodedkey)) {
+                  var coded_day = this.by_data.BYDAY[daycodedkey];
+                  var bydayParts = this.ruleDayOfWeek(coded_day);
+                  var pos = bydayParts[0];
+                  var dow = bydayParts[1];
+                  var month_day;
 
-                if (month_day > 0) {
-                  this.days.push(doy_offset + month_day);
+                  var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
+                  var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
+
+                  if (pos == 0) {
+                    for (var day = first_matching_day; day <= daysInMonth; day += 7) {
+                      this.days.push(doy_offset + day);
+                    }
+                  } else if (pos > 0) {
+                    month_day = first_matching_day + (pos - 1) * 7;
+
+                    if (month_day <= daysInMonth) {
+                      this.days.push(doy_offset + month_day);
+                    }
+                  } else {
+                    month_day = last_matching_day + (pos + 1) * 7;
+
+                    if (month_day > 0) {
+                      this.days.push(doy_offset + month_day);
+                    }
+                  }
                 }
               }
             }
@@ -1094,10 +1118,13 @@ ICAL.RecurIterator = (function() {
         var expandedDays = this.expand_by_day(aYear);
 
         for (var daykey in expandedDays) {
-          var day = expandedDays[daykey];
-          var tt = ICAL.Time.fromDayOfYear(day, aYear);
-          if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-            this.days.push(day);
+          /* istanbul ignore else */
+          if (expandedDays.hasOwnProperty(daykey)) {
+            var day = expandedDays[daykey];
+            var tt = ICAL.Time.fromDayOfYear(day, aYear);
+            if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+              this.days.push(day);
+            }
           }
         }
       } else if (partCount == 3 &&
@@ -1107,24 +1134,30 @@ ICAL.RecurIterator = (function() {
         var expandedDays = this.expand_by_day(aYear);
 
         for (var daykey in expandedDays) {
-          var day = expandedDays[daykey];
-          var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          /* istanbul ignore else */
+          if (expandedDays.hasOwnProperty(daykey)) {
+            var day = expandedDays[daykey];
+            var tt = ICAL.Time.fromDayOfYear(day, aYear);
 
-          if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
-              this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-            this.days.push(day);
+            if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
+                this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+              this.days.push(day);
+            }
           }
         }
       } else if (partCount == 2 && "BYDAY" in parts && "BYWEEKNO" in parts) {
         var expandedDays = this.expand_by_day(aYear);
 
         for (var daykey in expandedDays) {
-          var day = expandedDays[daykey];
-          var tt = ICAL.Time.fromDayOfYear(day, aYear);
-          var weekno = tt.weekNumber(this.rule.wkst);
+          /* istanbul ignore else */
+          if (expandedDays.hasOwnProperty(daykey)) {
+            var day = expandedDays[daykey];
+            var tt = ICAL.Time.fromDayOfYear(day, aYear);
+            var weekno = tt.weekNumber(this.rule.wkst);
 
-          if (this.by_data.BYWEEKNO.indexOf(weekno)) {
-            this.days.push(day);
+            if (this.by_data.BYWEEKNO.indexOf(weekno)) {
+              this.days.push(day);
+            }
           }
         }
       } else if (partCount == 3 &&
@@ -1160,38 +1193,41 @@ ICAL.RecurIterator = (function() {
       var end_year_day = tmp.dayOfYear();
 
       for (var daykey in this.by_data.BYDAY) {
-        var day = this.by_data.BYDAY[daykey];
-        var parts = this.ruleDayOfWeek(day);
-        var pos = parts[0];
-        var dow = parts[1];
+        /* istanbul ignore else */
+        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          var day = this.by_data.BYDAY[daykey];
+          var parts = this.ruleDayOfWeek(day);
+          var pos = parts[0];
+          var dow = parts[1];
 
-        if (pos == 0) {
-          var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
+          if (pos == 0) {
+            var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
 
-          for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
-            days_list.push(doy);
-          }
+            for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
+              days_list.push(doy);
+            }
 
-        } else if (pos > 0) {
-          var first;
-          if (dow >= start_dow) {
-            first = dow - start_dow + 1;
+          } else if (pos > 0) {
+            var first;
+            if (dow >= start_dow) {
+              first = dow - start_dow + 1;
+            } else {
+              first = dow - start_dow + 8;
+            }
+
+            days_list.push(first + (pos - 1) * 7);
           } else {
-            first = dow - start_dow + 8;
+            var last;
+            pos = -pos;
+
+            if (dow <= end_dow) {
+              last = end_year_day - end_dow + dow;
+            } else {
+              last = end_year_day - end_dow + dow - 7;
+            }
+
+            days_list.push(last - (pos - 1) * 7);
           }
-
-          days_list.push(first + (pos - 1) * 7);
-        } else {
-          var last;
-          pos = -pos;
-
-          if (dow <= end_dow) {
-            last = end_year_day - end_dow + dow;
-          } else {
-            last = end_year_day - end_dow + dow - 7;
-          }
-
-          days_list.push(last - (pos - 1) * 7);
         }
       }
       return days_list;
@@ -1199,15 +1235,18 @@ ICAL.RecurIterator = (function() {
 
     is_day_in_byday: function is_day_in_byday(tt) {
       for (var daykey in this.by_data.BYDAY) {
-        var day = this.by_data.BYDAY[daykey];
-        var parts = this.ruleDayOfWeek(day);
-        var pos = parts[0];
-        var dow = parts[1];
-        var this_dow = tt.dayOfWeek();
+        /* istanbul ignore else */
+        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          var day = this.by_data.BYDAY[daykey];
+          var parts = this.ruleDayOfWeek(day);
+          var pos = parts[0];
+          var dow = parts[1];
+          var this_dow = tt.dayOfWeek();
 
-        if ((pos == 0 && dow == this_dow) ||
-            (tt.nthWeekDay(dow, pos) == tt.day)) {
-          return 1;
+          if ((pos == 0 && dow == this_dow) ||
+              (tt.nthWeekDay(dow, pos) == tt.day)) {
+            return 1;
+          }
         }
       }
 
@@ -1261,9 +1300,12 @@ ICAL.RecurIterator = (function() {
         var ruleType = this.by_data[aRuleType];
 
         for (var bydatakey in ruleType) {
-          if (ruleType[bydatakey] == v) {
-            pass = true;
-            break;
+          /* istanbul ignore else */
+          if (ruleType.hasOwnProperty(bydatakey)) {
+            if (ruleType[bydatakey] == v) {
+              pass = true;
+              break;
+            }
           }
         }
       } else {

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -251,36 +251,37 @@ ICAL.RecurIterator = (function() {
         // Check every weekday in BYDAY with relative dow and pos.
         for (var i in this.by_data.BYDAY) {
           /* istanbul ignore else */
-          if (this.by_data.BYDAY.hasOwnProperty(i)) {
-            this.last = initLast.clone();
-            var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
-            var pos = bydayParts[0];
-            var dow = bydayParts[1];
-            var dayOfMonth = this.last.nthWeekDay(dow, pos);
+          if (!this.by_data.BYDAY.hasOwnProperty(i)) {
+            continue;
+          }
+          this.last = initLast.clone();
+          var bydayParts = this.ruleDayOfWeek(this.by_data.BYDAY[i]);
+          var pos = bydayParts[0];
+          var dow = bydayParts[1];
+          var dayOfMonth = this.last.nthWeekDay(dow, pos);
 
-            // If |pos| >= 6, the byday is invalid for a monthly rule.
-            if (pos >= 6 || pos <= -6) {
-              throw new Error("Malformed values in BYDAY part");
-            }
+          // If |pos| >= 6, the byday is invalid for a monthly rule.
+          if (pos >= 6 || pos <= -6) {
+            throw new Error("Malformed values in BYDAY part");
+          }
 
-            // If a Byday with pos=+/-5 is not in the current month it
-            // must be searched in the next months.
-            if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-              // Skip if we have already found a "last" in this month.
-              if (tempLast && tempLast.month == initLast.month) {
-                continue;
-              }
-              while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
-                this.increment_month();
-                daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
-                dayOfMonth = this.last.nthWeekDay(dow, pos);
-              }
+          // If a Byday with pos=+/-5 is not in the current month it
+          // must be searched in the next months.
+          if (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+            // Skip if we have already found a "last" in this month.
+            if (tempLast && tempLast.month == initLast.month) {
+              continue;
             }
+            while (dayOfMonth > daysInMonth || dayOfMonth <= 0) {
+              this.increment_month();
+              daysInMonth = ICAL.Time.daysInMonth(this.last.month, this.last.year);
+              dayOfMonth = this.last.nthWeekDay(dow, pos);
+            }
+          }
 
-            this.last.day = dayOfMonth;
-            if (!tempLast || this.last.compare(tempLast) < 0) {
-              tempLast = this.last.clone();
-            }
+          this.last.day = dayOfMonth;
+          if (!tempLast || this.last.compare(tempLast) < 0) {
+            tempLast = this.last.clone();
           }
         }
         this.last = tempLast.clone();
@@ -985,53 +986,57 @@ ICAL.RecurIterator = (function() {
       } else if (partCount == 1 && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
-            var t2 = this.dtstart.clone();
-            t2.year = aYear;
-            t2.month = this.by_data.BYMONTH[monthkey];
-            t2.isDate = true;
-            this.days.push(t2.dayOfYear());
+          if (!this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            continue;
           }
+          var t2 = this.dtstart.clone();
+          t2.year = aYear;
+          t2.month = this.by_data.BYMONTH[monthkey];
+          t2.isDate = true;
+          this.days.push(t2.dayOfYear());
         }
       } else if (partCount == 1 && "BYMONTHDAY" in parts) {
         for (var monthdaykey in this.by_data.BYMONTHDAY) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
-            var t3 = this.dtstart.clone();
-            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-            if (day_ < 0) {
-              var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
-              day_ = day_ + daysInMonth + 1;
-            }
-            t3.day = day_;
-            t3.year = aYear;
-            t3.isDate = true;
-            this.days.push(t3.dayOfYear());
+          if (!this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+            continue;
           }
+          var t3 = this.dtstart.clone();
+          var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+          if (day_ < 0) {
+            var daysInMonth = ICAL.Time.daysInMonth(t3.month, aYear);
+            day_ = day_ + daysInMonth + 1;
+          }
+          t3.day = day_;
+          t3.year = aYear;
+          t3.isDate = true;
+          this.days.push(t3.dayOfYear());
         }
       } else if (partCount == 2 &&
                  "BYMONTHDAY" in parts &&
                  "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
-            var month_ = this.by_data.BYMONTH[monthkey];
-            var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
-            for (var monthdaykey in this.by_data.BYMONTHDAY) {
-              /* istanbul ignore else */
-              if (this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
-                var day_ = this.by_data.BYMONTHDAY[monthdaykey];
-                if (day_ < 0) {
-                  day_ = day_ + daysInMonth + 1;
-                }
-                t.day = day_;
-                t.month = month_;
-                t.year = aYear;
-                t.isDate = true;
-
-                this.days.push(t.dayOfYear());
-              }
+          if (!this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            continue;
+          }
+          var month_ = this.by_data.BYMONTH[monthkey];
+          var daysInMonth = ICAL.Time.daysInMonth(month_, aYear);
+          for (var monthdaykey in this.by_data.BYMONTHDAY) {
+            /* istanbul ignore else */
+            if (!this.by_data.BYMONTHDAY.hasOwnProperty(monthdaykey)) {
+              continue;
             }
+            var day_ = this.by_data.BYMONTHDAY[monthdaykey];
+            if (day_ < 0) {
+              day_ = day_ + daysInMonth + 1;
+            }
+            t.day = day_;
+            t.month = month_;
+            t.year = aYear;
+            t.isDate = true;
+
+            this.days.push(t.dayOfYear());
           }
         }
       } else if (partCount == 1 && "BYWEEKNO" in parts) {
@@ -1045,67 +1050,69 @@ ICAL.RecurIterator = (function() {
       } else if (partCount == 2 && "BYDAY" in parts && "BYMONTH" in parts) {
         for (var monthkey in this.by_data.BYMONTH) {
           /* istanbul ignore else */
-          if (this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
-            var month = this.by_data.BYMONTH[monthkey];
-            var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
+          if (!this.by_data.BYMONTH.hasOwnProperty(monthkey)) {
+            continue;
+          }
+          var month = this.by_data.BYMONTH[monthkey];
+          var daysInMonth = ICAL.Time.daysInMonth(month, aYear);
 
-            t.year = aYear;
-            t.month = this.by_data.BYMONTH[monthkey];
-            t.day = 1;
-            t.isDate = true;
+          t.year = aYear;
+          t.month = this.by_data.BYMONTH[monthkey];
+          t.day = 1;
+          t.isDate = true;
 
-            var first_dow = t.dayOfWeek();
-            var doy_offset = t.dayOfYear() - 1;
+          var first_dow = t.dayOfWeek();
+          var doy_offset = t.dayOfYear() - 1;
 
-            t.day = daysInMonth;
-            var last_dow = t.dayOfWeek();
+          t.day = daysInMonth;
+          var last_dow = t.dayOfWeek();
 
-            if (this.has_by_data("BYSETPOS")) {
-              var set_pos_counter = 0;
-              var by_month_day = [];
-              for (var day = 1; day <= daysInMonth; day++) {
-                t.day = day;
-                if (this.is_day_in_byday(t)) {
-                  by_month_day.push(day);
-                }
+          if (this.has_by_data("BYSETPOS")) {
+            var set_pos_counter = 0;
+            var by_month_day = [];
+            for (var day = 1; day <= daysInMonth; day++) {
+              t.day = day;
+              if (this.is_day_in_byday(t)) {
+                by_month_day.push(day);
               }
+            }
 
-              for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
-                if (this.check_set_position(spIndex + 1) ||
-                    this.check_set_position(spIndex - by_month_day.length)) {
-                  this.days.push(doy_offset + by_month_day[spIndex]);
-                }
+            for (var spIndex = 0; spIndex < by_month_day.length; spIndex++) {
+              if (this.check_set_position(spIndex + 1) ||
+                  this.check_set_position(spIndex - by_month_day.length)) {
+                this.days.push(doy_offset + by_month_day[spIndex]);
               }
-            } else {
-              for (var daycodedkey in this.by_data.BYDAY) {
-                /* istanbul ignore else */
-                if (this.by_data.BYDAY.hasOwnProperty(daycodedkey)) {
-                  var coded_day = this.by_data.BYDAY[daycodedkey];
-                  var bydayParts = this.ruleDayOfWeek(coded_day);
-                  var pos = bydayParts[0];
-                  var dow = bydayParts[1];
-                  var month_day;
+            }
+          } else {
+            for (var daycodedkey in this.by_data.BYDAY) {
+              /* istanbul ignore else */
+              if (!this.by_data.BYDAY.hasOwnProperty(daycodedkey)) {
+                continue;
+              }
+              var coded_day = this.by_data.BYDAY[daycodedkey];
+              var bydayParts = this.ruleDayOfWeek(coded_day);
+              var pos = bydayParts[0];
+              var dow = bydayParts[1];
+              var month_day;
 
-                  var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
-                  var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
+              var first_matching_day = ((dow + 7 - first_dow) % 7) + 1;
+              var last_matching_day = daysInMonth - ((last_dow + 7 - dow) % 7);
 
-                  if (pos == 0) {
-                    for (var day = first_matching_day; day <= daysInMonth; day += 7) {
-                      this.days.push(doy_offset + day);
-                    }
-                  } else if (pos > 0) {
-                    month_day = first_matching_day + (pos - 1) * 7;
+              if (pos == 0) {
+                for (var day = first_matching_day; day <= daysInMonth; day += 7) {
+                  this.days.push(doy_offset + day);
+                }
+              } else if (pos > 0) {
+                month_day = first_matching_day + (pos - 1) * 7;
 
-                    if (month_day <= daysInMonth) {
-                      this.days.push(doy_offset + month_day);
-                    }
-                  } else {
-                    month_day = last_matching_day + (pos + 1) * 7;
+                if (month_day <= daysInMonth) {
+                  this.days.push(doy_offset + month_day);
+                }
+              } else {
+                month_day = last_matching_day + (pos + 1) * 7;
 
-                    if (month_day > 0) {
-                      this.days.push(doy_offset + month_day);
-                    }
-                  }
+                if (month_day > 0) {
+                  this.days.push(doy_offset + month_day);
                 }
               }
             }
@@ -1119,12 +1126,13 @@ ICAL.RecurIterator = (function() {
 
         for (var daykey in expandedDays) {
           /* istanbul ignore else */
-          if (expandedDays.hasOwnProperty(daykey)) {
-            var day = expandedDays[daykey];
-            var tt = ICAL.Time.fromDayOfYear(day, aYear);
-            if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-              this.days.push(day);
-            }
+          if (!expandedDays.hasOwnProperty(daykey)) {
+            continue;
+          }
+          var day = expandedDays[daykey];
+          var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          if (this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+            this.days.push(day);
           }
         }
       } else if (partCount == 3 &&
@@ -1135,14 +1143,15 @@ ICAL.RecurIterator = (function() {
 
         for (var daykey in expandedDays) {
           /* istanbul ignore else */
-          if (expandedDays.hasOwnProperty(daykey)) {
-            var day = expandedDays[daykey];
-            var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          if (!expandedDays.hasOwnProperty(daykey)) {
+            continue;
+          }
+          var day = expandedDays[daykey];
+          var tt = ICAL.Time.fromDayOfYear(day, aYear);
 
-            if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
-                this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
-              this.days.push(day);
-            }
+          if (this.by_data.BYMONTH.indexOf(tt.month) >= 0 &&
+              this.by_data.BYMONTHDAY.indexOf(tt.day) >= 0) {
+            this.days.push(day);
           }
         }
       } else if (partCount == 2 && "BYDAY" in parts && "BYWEEKNO" in parts) {
@@ -1150,14 +1159,15 @@ ICAL.RecurIterator = (function() {
 
         for (var daykey in expandedDays) {
           /* istanbul ignore else */
-          if (expandedDays.hasOwnProperty(daykey)) {
-            var day = expandedDays[daykey];
-            var tt = ICAL.Time.fromDayOfYear(day, aYear);
-            var weekno = tt.weekNumber(this.rule.wkst);
+          if (!expandedDays.hasOwnProperty(daykey)) {
+            continue;
+          }
+          var day = expandedDays[daykey];
+          var tt = ICAL.Time.fromDayOfYear(day, aYear);
+          var weekno = tt.weekNumber(this.rule.wkst);
 
-            if (this.by_data.BYWEEKNO.indexOf(weekno)) {
-              this.days.push(day);
-            }
+          if (this.by_data.BYWEEKNO.indexOf(weekno)) {
+            this.days.push(day);
           }
         }
       } else if (partCount == 3 &&
@@ -1194,40 +1204,41 @@ ICAL.RecurIterator = (function() {
 
       for (var daykey in this.by_data.BYDAY) {
         /* istanbul ignore else */
-        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
-          var day = this.by_data.BYDAY[daykey];
-          var parts = this.ruleDayOfWeek(day);
-          var pos = parts[0];
-          var dow = parts[1];
+        if (!this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          continue;
+        }
+        var day = this.by_data.BYDAY[daykey];
+        var parts = this.ruleDayOfWeek(day);
+        var pos = parts[0];
+        var dow = parts[1];
 
-          if (pos == 0) {
-            var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
+        if (pos == 0) {
+          var tmp_start_doy = ((dow + 7 - start_dow) % 7) + 1;
 
-            for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
-              days_list.push(doy);
-            }
-
-          } else if (pos > 0) {
-            var first;
-            if (dow >= start_dow) {
-              first = dow - start_dow + 1;
-            } else {
-              first = dow - start_dow + 8;
-            }
-
-            days_list.push(first + (pos - 1) * 7);
-          } else {
-            var last;
-            pos = -pos;
-
-            if (dow <= end_dow) {
-              last = end_year_day - end_dow + dow;
-            } else {
-              last = end_year_day - end_dow + dow - 7;
-            }
-
-            days_list.push(last - (pos - 1) * 7);
+          for (var doy = tmp_start_doy; doy <= end_year_day; doy += 7) {
+            days_list.push(doy);
           }
+
+        } else if (pos > 0) {
+          var first;
+          if (dow >= start_dow) {
+            first = dow - start_dow + 1;
+          } else {
+            first = dow - start_dow + 8;
+          }
+
+          days_list.push(first + (pos - 1) * 7);
+        } else {
+          var last;
+          pos = -pos;
+
+          if (dow <= end_dow) {
+            last = end_year_day - end_dow + dow;
+          } else {
+            last = end_year_day - end_dow + dow - 7;
+          }
+
+          days_list.push(last - (pos - 1) * 7);
         }
       }
       return days_list;
@@ -1236,17 +1247,18 @@ ICAL.RecurIterator = (function() {
     is_day_in_byday: function is_day_in_byday(tt) {
       for (var daykey in this.by_data.BYDAY) {
         /* istanbul ignore else */
-        if (this.by_data.BYDAY.hasOwnProperty(daykey)) {
-          var day = this.by_data.BYDAY[daykey];
-          var parts = this.ruleDayOfWeek(day);
-          var pos = parts[0];
-          var dow = parts[1];
-          var this_dow = tt.dayOfWeek();
+        if (!this.by_data.BYDAY.hasOwnProperty(daykey)) {
+          continue;
+        }
+        var day = this.by_data.BYDAY[daykey];
+        var parts = this.ruleDayOfWeek(day);
+        var pos = parts[0];
+        var dow = parts[1];
+        var this_dow = tt.dayOfWeek();
 
-          if ((pos == 0 && dow == this_dow) ||
-              (tt.nthWeekDay(dow, pos) == tt.day)) {
-            return 1;
-          }
+        if ((pos == 0 && dow == this_dow) ||
+            (tt.nthWeekDay(dow, pos) == tt.day)) {
+          return 1;
         }
       }
 

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -187,9 +187,12 @@
     fromData: function fromData(aData, aZone) {
       if (aData) {
         for (var key in aData) {
-          // ical type cannot be set
-          if (key === 'icaltype') continue;
-          this[key] = aData[key];
+          /* istanbul ignore else */
+          if (Object.prototype.hasOwnProperty.call(aData, key)) {
+            // ical type cannot be set
+            if (key === 'icaltype') continue;
+            this[key] = aData[key];
+          }
         }
       }
 

--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -139,9 +139,12 @@
 
         // Copy remaining passed properties
         for (var key in OPTIONS) {
-          var prop = OPTIONS[key];
-          if (aData && prop in aData) {
-            this[prop] = aData[prop];
+          /* istanbul ignore else */
+          if (OPTIONS.hasOwnProperty(key)) {
+            var prop = OPTIONS[key];
+            if (aData && prop in aData) {
+              this[prop] = aData[prop];
+            }
           }
         }
       }
@@ -333,35 +336,38 @@
       } else {
         var props = aComponent.getAllProperties("rdate");
         for (var rdatekey in props) {
-          var rdate = props[rdatekey];
-          var time = rdate.getFirstValue();
-          change = init_changes();
+          /* istanbul ignore else */
+          if (props.hasOwnProperty(rdatekey)) {
+            var rdate = props[rdatekey];
+            var time = rdate.getFirstValue();
+            change = init_changes();
 
-          change.year = time.year;
-          change.month = time.month;
-          change.day = time.day;
+            change.year = time.year;
+            change.month = time.month;
+            change.day = time.day;
 
-          if (time.isDate) {
-            change.hour = dtstart.hour;
-            change.minute = dtstart.minute;
-            change.second = dtstart.second;
+            if (time.isDate) {
+              change.hour = dtstart.hour;
+              change.minute = dtstart.minute;
+              change.second = dtstart.second;
 
-            if (dtstart.zone != ICAL.Timezone.utcTimezone) {
-              ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                              -change.prevUtcOffset);
+              if (dtstart.zone != ICAL.Timezone.utcTimezone) {
+                ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                                -change.prevUtcOffset);
+              }
+            } else {
+              change.hour = time.hour;
+              change.minute = time.minute;
+              change.second = time.second;
+
+              if (time.zone != ICAL.Timezone.utcTimezone) {
+                ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                                -change.prevUtcOffset);
+              }
             }
-          } else {
-            change.hour = time.hour;
-            change.minute = time.minute;
-            change.second = time.second;
 
-            if (time.zone != ICAL.Timezone.utcTimezone) {
-              ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                              -change.prevUtcOffset);
-            }
+            changes.push(change);
           }
-
-          changes.push(change);
         }
 
         var rrule = aComponent.getFirstProperty("rrule");

--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -337,37 +337,38 @@
         var props = aComponent.getAllProperties("rdate");
         for (var rdatekey in props) {
           /* istanbul ignore else */
-          if (props.hasOwnProperty(rdatekey)) {
-            var rdate = props[rdatekey];
-            var time = rdate.getFirstValue();
-            change = init_changes();
-
-            change.year = time.year;
-            change.month = time.month;
-            change.day = time.day;
-
-            if (time.isDate) {
-              change.hour = dtstart.hour;
-              change.minute = dtstart.minute;
-              change.second = dtstart.second;
-
-              if (dtstart.zone != ICAL.Timezone.utcTimezone) {
-                ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                                -change.prevUtcOffset);
-              }
-            } else {
-              change.hour = time.hour;
-              change.minute = time.minute;
-              change.second = time.second;
-
-              if (time.zone != ICAL.Timezone.utcTimezone) {
-                ICAL.Timezone.adjust_change(change, 0, 0, 0,
-                                                -change.prevUtcOffset);
-              }
-            }
-
-            changes.push(change);
+          if (!props.hasOwnProperty(rdatekey)) {
+            continue;
           }
+          var rdate = props[rdatekey];
+          var time = rdate.getFirstValue();
+          change = init_changes();
+
+          change.year = time.year;
+          change.month = time.month;
+          change.day = time.day;
+
+          if (time.isDate) {
+            change.hour = dtstart.hour;
+            change.minute = dtstart.minute;
+            change.second = dtstart.second;
+
+            if (dtstart.zone != ICAL.Timezone.utcTimezone) {
+              ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                              -change.prevUtcOffset);
+            }
+          } else {
+            change.hour = time.hour;
+            change.minute = time.minute;
+            change.second = time.second;
+
+            if (time.zone != ICAL.Timezone.utcTimezone) {
+              ICAL.Timezone.adjust_change(change, 0, 0, 0,
+                                              -change.prevUtcOffset);
+            }
+          }
+
+          changes.push(change);
         }
 
         var rrule = aComponent.getFirstProperty("rrule");

--- a/lib/ical/utc_offset.js
+++ b/lib/ical/utc_offset.js
@@ -75,7 +75,10 @@ ICAL.UtcOffset = (function() {
     fromData: function(aData) {
       if (aData) {
         for (var key in aData) {
-          this[key] = aData[key];
+          /* istanbul ignore else */
+          if (aData.hasOwnProperty(key)) {
+            this[key] = aData[key];
+          }
         }
       }
       this._normalize();


### PR DESCRIPTION
Code in for..in loops break when ical.js is used in combination with code that adds functions to the prototype of Arrays. A simple hasOwnProperty check in the loops solves that this.
