### PR TITLE
Support minification with uglify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ api
 jsdoc-stage
 coverage/
 build/benchmark/ical_upstream.js
+build/ical.min.js
+build/ical.min.js.map
 junk/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,6 +132,22 @@ module.exports = function(grunt) {
         src: ['tools/ICALTester/**/*.js']
       }
     },
+    uglify: {
+      options: {
+        sourceMap: true,
+        preserveComments: false,
+        screwIE8: true,
+        compress: {},
+        mangle: {
+          except: ['ICAL']
+        }
+      },
+      dist: {
+        files: {
+          'build/ical.min.js': ['build/ical.js']
+        }
+      }
+    },
     release: {
       options: {
         tagName: 'v<%=version%>',
@@ -177,6 +193,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-concurrent');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-coveralls');
   grunt.loadNpmTasks('grunt-gjslint');
   grunt.loadNpmTasks('grunt-gh-pages');
@@ -189,7 +206,7 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   grunt.registerTask('default', ['package']);
-  grunt.registerTask('package', ['concat']);
+  grunt.registerTask('package', ['concat', 'uglify']);
   grunt.registerTask('coverage', 'mocha_istanbul');
   grunt.registerTask('linters', ['jshint', 'gjslint', 'check-browser-build']);
   grunt.registerTask('test-server', ['test-agent-config', 'run-test-server']);

--- a/README.md
+++ b/README.md
@@ -126,3 +126,6 @@ single-file build for use in the browser. This file needs to be checked in (in
 a separate commit) and can be found in [build/ical.js](build/ical.js). Please
 see [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
+Running the `package` target will also create a minified version in
+`build/ical.min.js`. This file is not pushed to the repository at the moment,
+but you can use it for front end projects.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-jshint": "^0.11.2",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-coveralls": "^1.0.0",
     "grunt-gh-pages": "^0.10.0",
     "grunt-gjslint": "^0.1.6",


### PR DESCRIPTION
I'm not going to have the minifed files pushed for now. I read about a release process that creates a branch, force-adds minified files, commits to branch and then tags that. This might be an option in the future to get minified files in the releases, which is especially nice for bower.
