### PR TITLE
Fixed bug where rrules saved to properties would be serialized incorrectly

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -760,7 +760,9 @@ ICAL.design = (function() {
               val = icalValues.date.toICAL(val);
             }
           } else if (k == "wkst") {
-            val = ICAL.Recur.numericDayToIcalDay(val);
+            if (typeof val === 'number') {
+              val = ICAL.Recur.numericDayToIcalDay(val);
+            }
           } else if (Array.isArray(val)) {
             val = val.join(",");
           }

--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -436,7 +436,9 @@ ICAL.design = (function() {
               val = icalValues.date.toICAL(val);
             }
           } else if (k == "wkst") {
-            val = ICAL.Recur.numericDayToIcalDay(val);
+            if (typeof val === 'number') {
+              val = ICAL.Recur.numericDayToIcalDay(val);
+            }
           } else if (Array.isArray(val)) {
             val = val.join(",");
           }

--- a/test/recur_test.js
+++ b/test/recur_test.js
@@ -453,6 +453,14 @@ suite('recur', function() {
       var comp = val.getComponent("byyearday");
       assert.deepEqual(comp, [20,30,40]);
     });
+
+    test('can be saved to a property that will be serialized correctly', function () {
+      var icalString = 'FREQ=WEEKLY;UNTIL=1970-01-03T00:00:00Z;WKST=SU;BYDAY=TU,TH';
+      var recur = ICAL.Recur.fromString(icalString);
+      var prop = new ICAL.Property('rrule');
+      prop.setValue(recur);
+      assert.equal(prop.toICAL(), 'RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=19700103T000000Z;WKST=SU');
+    });
   });
 
   suite('#toString', function() {


### PR DESCRIPTION
When setting a property value with a rrule it will undecorate the rrule, that
will translate the wkst from a number to a string. If the property later is
serialized to an ICAL string, the wkst field will be undefined.
