### PR TITLE
ical.js@1.2.0 has grunt as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,6 @@
     "sync-exec": "^0.6.0",
     "test-agent": "~0.28.2"
   },
-  "optionalDependencies": {
-    "grunt-node-inspector": "^0.4.1"
-  },
   "license": "MPL-2.0",
   "engine": {
     "node": ">=0.4"


### PR DESCRIPTION
why? it's unnecessary and is breaking my build due to unmet peer dependencies. this seems to be caused by `grunt-node-inspector`.

also, i don't see v1.2.0 in git
