### PR TITLE
Validator broken:ReferenceError: ICAL is not defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ tools/tzurl
 tools/libical
 zoneinfo
 api
-jsdoc-stage
+ghpages-stage
+/validator.html
 coverage/
 build/benchmark/ical_upstream.js
 junk/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,20 +29,37 @@ module.exports = function(grunt) {
         unit: ['test/*_test.js'],
         acceptance: ['test/acceptance/*_test.js'],
         performance: ['test/performance/*_test.js']
+      },
+      validator: {
+        dev: 'https://rawgit.com/mozilla-comm/ical.js/master/build/ical.js',
+        prod: 'https://cdn.rawgit.com/mozilla-comm/ical.js/<%= travis.commit %>/build/ical.js',
+        dest: 'validator.html'
       }
     },
 
     concat: {
       options: {
-        separator: '',
-        process: function(src, filepath) {
-          return src.replace('"use strict";', '');
-        }
+        separator: ''
       },
 
       dist: {
+        options: {
+          process: function(src, filepath) {
+            return src.replace('"use strict";', '');
+          }
+        },
         src: ['<%= libinfo.absfiles %>'],
         dest: 'build/ical.js'
+      },
+
+      validator: {
+        options: {
+          process: function(src, filepath) {
+            return src.replace(grunt.config('libinfo.validator.dev'), grunt.config('libinfo.validator.prod'));
+          }
+        },
+        src: ['sandbox/validator.html'],
+        dest: '<%= libinfo.validator.dest %>'
       }
     },
 
@@ -235,16 +252,16 @@ module.exports = function(grunt) {
 
     'gh-pages': {
       options: {
-        clone: 'jsdoc-stage',
+        clone: 'ghpages-stage',
         only: '<%= libinfo.doc %>',
         user: {
           name: 'Travis CI',
           email: 'builds@travis-ci.org',
         },
         repo: 'git@github.com:mozilla-comm/ical.js.git',
-        message: 'Update API Documentation for <%= travis.commit %>'
+        message: 'Update API documentation and validator for <%= travis.commit %>'
       },
-      src: '<%= libinfo.doc %>/**'
+      src: ['<%= libinfo.doc %>/**', '<%= libinfo.validator.dest %>']
     }
   });
 
@@ -273,16 +290,16 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   grunt.registerTask('default', ['package']);
-  grunt.registerTask('package', ['concat', 'uglify']);
+  grunt.registerTask('package', ['concat:dist', 'uglify']);
   grunt.registerTask('coverage', 'mocha_istanbul');
   grunt.registerTask('linters', ['jshint', 'gjslint', 'check-browser-build']);
   grunt.registerTask('test-server', ['test-agent-config', 'run-test-server']);
   grunt.registerTask('test', ['test-browser', 'test-node']);
 
-  grunt.registerTask('doc-ci', ['jsdoc', 'run-on-master-leader:run-with-env:GITHUB_SSH_KEY:gh-pages']);
+  grunt.registerTask('ghpages-ci', ['jsdoc', 'concat:validator', 'run-on-master-leader:run-with-env:GITHUB_SSH_KEY:gh-pages']);
   grunt.registerTask('unit-ci', ['test-node:unit', 'test-node:acceptance', 'run-on-master-leader:karma:ci']);
   grunt.registerTask('coverage-ci', ['coverage', 'coveralls']);
-  grunt.registerTask('test-ci', ['check-browser-build', 'linters', 'unit-ci', 'coverage-ci', 'doc-ci']);
+  grunt.registerTask('test-ci', ['check-browser-build', 'linters', 'unit-ci', 'coverage-ci', 'ghpages-ci']);
 
   // Additional tasks:
   //   - tests.js: performance-update, test-node, test-browser,

--- a/sandbox/validator.html
+++ b/sandbox/validator.html
@@ -17,7 +17,7 @@
         border: 1px solid black;
       }
     </style>
-    <script type="text/javascript" src="https://raw.github.com/mozilla-comm/ical.js/master/build/ical.js"></script>
+    <script type="text/javascript" src="https://rawgit.com/mozilla-comm/ical.js/master/build/ical.js"></script>
     <script type="text/javascript">
       function stringError(e) {
         return "Error: " + e +


### PR DESCRIPTION
I was trying out the validator here: http://mozilla-comm.github.io/ical.js/validator.html with some sample data and it seems to always crash with the same error. For example I copied in

`BEGIN:VCALENDAR
CALSCALE:GREGORIAN
PRODID:-//Example Inc.//Example Calendar//EN
VERSION:2.0
BEGIN:VEVENT
DTSTAMP:20080205T191224Z
DTSTART:20081006
SUMMARY:Planning meeting
UID:4088E990AD89CB3DBB484909
END:VEVENT
END:VCALENDAR`

The error is:
`Couldn't parse as iCalendar:
Error: ReferenceError: ICAL is not defined
Stack: ReferenceError: ICAL is not defined
    at validate (http://mozilla-comm.github.io/ical.js/validator.html:49:24)
    at HTMLFormElement.onsubmit (http://mozilla-comm.github.io/ical.js/validator.html:85:72)
`
