### PR TITLE
Correct parsing of RRULE parts. Fixes #292

### DIFF
--- a/build/ical.js
+++ b/build/ical.js
@@ -4728,6 +4728,8 @@ ICAL.TimezoneService = (function() {
           } else {
             this.parts[uckey] = [data[key]];
           }
+        } else if (uckey in optionDesign) {
+          optionDesign[uckey](data[key], this);
         } else {
           this[key] = data[key];
         }

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -112,6 +112,8 @@
           } else {
             this.parts[uckey] = [data[key]];
           }
+        } else if (uckey in optionDesign) {
+          optionDesign[uckey](data[key], this);
         } else {
           this[key] = data[key];
         }


### PR DESCRIPTION
Hey @kewisch,

This fixes our issue on the 1.0.x branch of ical.js
I've no idea how to write tests for it, and to be honest I didn't even check if this broke anything :fearful: 

  
Details:

I've tracked down the issue to `icaltime_compare` which erroneously return `0` if one of the two compared Time instances have `NaN` as the unix time. How is that even possible, you'd say?
In our case, because when the recurrence iterator moves forward the years, it calls `increment_xxx` methods that uses the `interval` of the recurrence rule which is supposed to be an integer. However, it is a String in our case, I'm not exactly sure why...

Forcing a correct parsing in the `fromData` method of the timezone component fixed it, making sure interval is a integer.
  

Can you give me your insights and ideas how to properly test this?

Thanks,
David