### PR TITLE
`_setTime` instead of `_setProp` for Event.recurrenceId

### DIFF
--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -487,7 +487,7 @@ ICAL.Event = (function() {
     },
 
     set recurrenceId(value) {
-      this._setProp('recurrence-id', value);
+      this._setTime('recurrence-id', value);
     },
 
     /**

--- a/test/event_test.js
+++ b/test/event_test.js
@@ -2,7 +2,7 @@ suite('ICAL.Event', function() {
 
 
   var testTzid = 'America/New_York';
-  testSupport.useTimezones(testTzid);
+  testSupport.useTimezones(testTzid, 'America/Denver');
 
   var icsData;
 
@@ -670,7 +670,6 @@ suite('ICAL.Event', function() {
 
       suite('#' + prop, function() {
         var tzid = 'America/Denver';
-        testSupport.useTimezones(tzid);
 
         setup(function() {
           timeProp = primaryItem.getFirstProperty(ical);
@@ -783,6 +782,20 @@ suite('ICAL.Event', function() {
 
       subject.recurrenceId = changeval;
       assert.deepEqual(subject.component.getFirstPropertyValue('recurrence-id'), changeval);
+
+      var tzid = 'America/New_York';
+      var changeval2 = new ICAL.Time({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 12,
+        minute: 13,
+        second: 14,
+        timezone: tzid
+      });
+
+      subject.recurrenceId = changeval2;
+      assert.deepEqual(subject.component.getFirstProperty('recurrence-id').getParameter("tzid"), tzid);
     });
   });
 


### PR DESCRIPTION
As discussed in https://github.com/mozilla-comm/ical.js/issues/342, `recurrence-id` value is of type `ICAL.Time`. I see no reason to use the generic `_setProp` that does not handle the `TZID` param correctly.