### PR TITLE
ICAL.Event duration should take timezones into account

### DIFF
--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -391,7 +391,7 @@ ICAL.Event = (function() {
     get duration() {
       var duration = this._firstProp('duration');
       if (!duration) {
-        return this.endDate.subtractDate(this.startDate);
+        return this.endDate.subtractDateTz(this.startDate);
       }
       return duration;
     },

--- a/test/event_test.js
+++ b/test/event_test.js
@@ -2,7 +2,7 @@ suite('ICAL.Event', function() {
 
 
   var testTzid = 'America/New_York';
-  testSupport.useTimezones(testTzid, 'America/Denver');
+  testSupport.useTimezones(testTzid, 'America/Denver', 'America/Los_Angeles');
 
   var icsData;
 
@@ -867,7 +867,7 @@ suite('ICAL.Event', function() {
           day: 2,
           hour: 6,
           isDate: false,
-          timezone: testTzid
+          timezone: subject.startDate.zone
       });
 
       assert.equal(subject.duration.toString(), 'P2D');
@@ -955,6 +955,49 @@ suite('ICAL.Event', function() {
     testSupport.defineSample('minimal.ics', function(data) {
       icsData = data;
     });
+
+    test('result with different timezones', function() {
+      var subject = (new ICAL.Component(ICAL.parse(icsData)))
+        .getFirstSubcomponent('vevent');
+      // 3 hours ahead of L.A.
+      subject.updatePropertyWithValue('dtstart', ICAL.Time.fromData({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 10,
+        minute: 20,
+        timezone: 'America/New_York'
+      }));
+      subject.updatePropertyWithValue('dtend', ICAL.Time.fromData({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 12,
+        minute: 50,
+        timezone: 'America/Los_Angeles'
+      }));
+
+      subject = new ICAL.Event(subject);
+      assert.equal(subject.startDate.toString(), ICAL.Time.fromData({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 10,
+        minute: 20,
+        timezone: 'America/New_York',
+      }).toString());
+
+      assert.equal(subject.endDate.toString(), ICAL.Time.fromData({
+        year: 2012,
+        month: 1,
+        day: 1,
+        hour: 12,
+        minute: 50,
+        timezone: 'America/Los_Angeles'
+      }).toString());
+
+      assert.equal(subject.duration.toString(), 'PT5H30M');
+    })
 
     test('set', function() {
       var subject = new ICAL.Component(ICAL.parse(icsData));


### PR DESCRIPTION
ICAL.Event has a getter for duration that either returns the duration property or calculates it from dtstart and dtend.

The calculation did not take timezones into account. Since RFC 5545 allows to define different timezones on DTSTART and DTEND, this behaviour is not appropriate.
Start: 01.01.2012 10:20 NYC
End: 01.01.2012 12:50 L.A.

previous duration was 2 1/2 hours,
when applying the fix the duration is correct: 5 1/2 hours