### PR TITLE
Update iCal.js URL in <script>

### DIFF
--- a/validator.html
+++ b/validator.html
@@ -17,7 +17,7 @@
         border: 1px solid black;
       }
     </style>
-    <script type="text/javascript" src="https://cdn.rawgit.com/mozilla-comm/ical.js/78122e661f584ad735ce33f6f3d08d7b91c0e4eb/build/ical.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/ical.js@1.3.0/build/ical.js"></script>
     <script type="text/javascript">
       function stringError(e) {
         return "Error: " + e +

--- a/validator.html
+++ b/validator.html
@@ -17,7 +17,7 @@
         border: 1px solid black;
       }
     </style>
-    <script type="text/javascript" src="https://unpkg.com/ical.js@1.3.0/build/ical.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/ical.js/build/ical.js"></script>
     <script type="text/javascript">
       function stringError(e) {
         return "Error: " + e +


### PR DESCRIPTION
[RawGit](https://rawgit.com), the service that was previously used to feed iCal.js into the validator, is no longer up and running. As such, the validator doesn't work (at all).
I've updated the URL to use [UNPKG](https://unpkg.com), a reliable CDN for everything on [npm](https://www.npmjs.com/).

The "new" validator can be viewed at https://calebdenio.me/ical.js/validator.