### PR TITLE
recur_expansion.js: EXDATE can be DATE and DTSTART can be DATE-TIME

### DIFF
--- a/lib/ical/component.js
+++ b/lib/ical/component.js
@@ -41,7 +41,7 @@ ICAL.Component = (function() {
   Component.prototype = {
     /**
      * Hydrated properties are inserted into the _properties array at the same
-     * position as in the jCal array, so its possible the array contains
+     * position as in the jCal array, so it is possible that the array contains
      * undefined values for unhydrdated properties. To avoid iterating the
      * array when checking if all properties have been hydrated, we save the
      * count here.

--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -283,13 +283,18 @@ ICAL.Event = (function() {
     },
 
     /**
-     * Checks if the event is recurring
+     * Checks if the event is recurring, thus has an RRULE or RDATE property, or a
+     * RECURRENCE-ID with the respective RANGE parameter.
      *
      * @return {Boolean}        True, if event is recurring
      */
     isRecurring: function() {
-      var comp = this.component;
-      return comp.hasProperty('rrule') || comp.hasProperty('rdate');
+        var comp = this.component, recurrenceId;
+        if (comp.hasProperty('rrule') || comp.hasProperty('rdate')) {
+            recurrenceId = comp.getFirstProperty('recurrence-id');
+            return !recurrenceId || !!recurrenceId.getParameter('range');
+        }
+        return false;
     },
 
     /**

--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -166,11 +166,11 @@ ICAL.parse = (function() {
      *    // ROLE= is a param because : has not happened yet
      */
       // when the parameter delimiter is after the
-      // value delimiter then its not a parameter.
+      // value delimiter then it is not a parameter.
 
     if ((paramPos !== -1 && valuePos !== -1)) {
       // when the parameter delimiter is after the
-      // value delimiter then its not a parameter.
+      // value delimiter then it is not a parameter.
       if (paramPos > valuePos) {
         paramPos = -1;
       }
@@ -213,14 +213,14 @@ ICAL.parse = (function() {
         state.component = state.stack.pop();
         return;
       }
-      // If its not begin/end, then this is a property with an empty value,
+      // If it is not begin/end, then this is a property with an empty value,
       // which should be considered valid.
     } else {
       /**
        * Invalid line.
        * The rational to throw an error is we will
        * never be certain that the rest of the file
-       * is sane and its unlikely that we can serialize
+       * is sane and it is unlikely that we can serialize
        * the result correctly either.
        */
       throw new ParserError(
@@ -270,7 +270,7 @@ ICAL.parse = (function() {
      *
      * I observed that building the array in pieces has adverse
      * effects on performance, so where possible we inline the creation.
-     * Its a little ugly but resulted in ~2000 additional ops/sec.
+     * It is a little ugly but resulted in ~2000 additional ops/sec.
      */
 
     var result;

--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -24,7 +24,7 @@ ICAL.Property = (function() {
    * property, with its parameters and value.
    *
    * @description
-   * Its important to note that mutations done in the wrapper
+   * It is important to note that mutations done in the wrapper
    * directly mutate the jCal object used to initialize.
    *
    * Can also be used to create new properties by passing
@@ -309,7 +309,7 @@ ICAL.Property = (function() {
       var len = this.jCal.length - VALUE_INDEX;
 
       if (len < 1) {
-        // its possible for a property to have no value.
+        // it is possible for a property to have no value.
         return [];
       }
 

--- a/lib/ical/recur_expansion.js
+++ b/lib/ical/recur_expansion.js
@@ -44,7 +44,7 @@ ICAL.RecurExpansion = (function() {
    * });
    *
    * // remember there are infinite rules
-   * // so its a good idea to limit the scope
+   * // so it is a good idea to limit the scope
    * // of the iterations then resume later on.
    *
    * // next is always an ICAL.Time or null

--- a/lib/ical/recur_expansion.js
+++ b/lib/ical/recur_expansion.js
@@ -214,6 +214,21 @@ ICAL.RecurExpansion = (function() {
     },
 
     /**
+     * Compare two ICAL.Time objects.  When the second parameter is a timeless date
+     * and the first parameter is date-with-time, strip the time and compare only
+     * the days.
+     *
+     * @private
+     * @param {ICAL.Time} a   The one object to compare
+     * @param {ICAL.Time} b   The other object to compare
+     */
+    _compare_special: function(a, b) {
+        if (!a.isDate && b.isDate)
+	    return new ICAL.Time({year:a.year, month:a.month, day:a.day}).compare(b);
+        else return a.compare(b);
+    },
+
+    /**
      * Retrieve the next occurrence in the series.
      * @return {ICAL.Time}
      */
@@ -264,9 +279,10 @@ ICAL.RecurExpansion = (function() {
 
         // check the negative rules
         if (this.exDate) {
-          compare = this.exDate.compare(this.last);
+          //EXDATE can be in DATE format, but DTSTART is in DATE-TIME format
+          compare = this._compare_special(this.last, this.exDate);
 
-          if (compare < 0) {
+          if (compare > 0) {
             this._nextExDay();
           }
 
@@ -418,10 +434,12 @@ ICAL.RecurExpansion = (function() {
       if (component.hasProperty('exdate')) {
         this.exDates = this._extractDates(component, 'exdate');
         // if we have a .last day we increment the index to beyond it.
+        // When DTSTART is in DATE-TIME format, EXDATE is in DATE format and EXDATE is
+        // the date of DTSTART, _compare_special finds this out and compareTime fails.
         this.exDateInc = ICAL.helpers.binsearchInsert(
           this.exDates,
           this.last,
-          compareTime
+          this._compare_special
         );
 
         this.exDate = this.exDates[this.exDateInc];

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -496,11 +496,11 @@ ICAL.RecurIterator = (function() {
 
         // negative case
         if (rule < 0) {
-          // we add (not subtract its a negative number)
+          // we add (not subtract it is a negative number)
           // one from the rule because 1 === last day of month
           rule = daysInMonth + (rule + 1);
         } else if (rule === 0) {
-          // skip zero its invalid.
+          // skip zero: it is invalid.
           continue;
         }
 
@@ -636,7 +636,7 @@ ICAL.RecurIterator = (function() {
           }
         }
 
-        // Its completely possible that the combination
+        // It is completely possible that the combination
         // cannot be matched in the current month.
         // When we reach the end of possible combinations
         // in the current month we iterate to the next one.

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -446,7 +446,7 @@
 
 
         // if the offset goes into the past
-        // week we add 7 so its goes into the next
+        // week we add 7 so it goes into the next
         // week. We only want to go forward in time here.
         if (offset < 0)
           // this is really important otherwise we would
@@ -495,7 +495,7 @@
      *
      * @param {ICAL.Time.weekDay} aDayOfWeek       Day of week to check
      * @param {Number} aPos                        Relative position
-     * @return {Boolean}                           True, if its the nth weekday
+     * @return {Boolean}                           True, if it is the nth weekday
      */
     isNthWeekDay: function(aDayOfWeek, aPos) {
       var dow = this.dayOfWeek();

--- a/lib/ical/timezone_service.js
+++ b/lib/ical/timezone_service.js
@@ -13,7 +13,7 @@ ICAL.TimezoneService = (function() {
 
   /**
    * @classdesc
-   * Singleton class to contain timezones.  Right now its all manual registry in
+   * Singleton class to contain timezones.  Right now it is all manual registry in
    * the future we may use this class to download timezone information or handle
    * loading pre-expanded timezones.
    *


### PR DESCRIPTION
When EXDATE is in DATE format and DTSTART is DATE-TIME, then to determine whether a ocurrence shall be excluded, the occurence shall be converted to DATE and then compared to EXDATE.

This applies also for the very first EXDATE, when it coincides with DTSTART.