### PR TITLE
Better handling of property groups

### DIFF
--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -232,9 +232,17 @@ ICAL.parse = (function() {
     var multiValue = false;
     var structuredValue = false;
     var propertyDetails;
+    var ungroupedName;
 
-    if (name in state.designSet.property) {
-      propertyDetails = state.designSet.property[name];
+    // fetch the ungrouped part of the name
+    if (name.indexOf('.') !== -1) {
+      ungroupedName = name.split('.')[1];
+    } else {
+      ungroupedName = name;
+    }
+
+    if (ungroupedName in state.designSet.property) {
+      propertyDetails = state.designSet.property[ungroupedName];
 
       if ('multiValue' in propertyDetails) {
         multiValue = propertyDetails.multiValue;

--- a/lib/ical/stringify.js
+++ b/lib/ical/stringify.js
@@ -111,6 +111,7 @@ ICAL.stringify = (function() {
     var line = name;
 
     var paramName;
+    var ungroupedJsName;
     for (paramName in params) {
       var value = params[paramName];
 
@@ -149,8 +150,15 @@ ICAL.stringify = (function() {
     var structuredValue = false;
     var isDefault = false;
 
-    if (jsName in designSet.property) {
-      propDetails = designSet.property[jsName];
+    // fetch the ungrouped part of the name
+    if (jsName.indexOf('.') !== -1) {
+      ungroupedJsName = jsName.split('.')[1];
+    } else {
+      ungroupedJsName = jsName;
+    }
+
+    if (ungroupedJsName in designSet.property) {
+      propDetails = designSet.property[ungroupedJsName];
 
       if ('multiValue' in propDetails) {
         multiValue = propDetails.multiValue;

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -37,7 +37,8 @@ suite('parserv2', function() {
       // vcard tests
       'vcard.vcf',
       'vcard_author.vcf',
-      'vcard3.vcf'
+      'vcard3.vcf',
+      'vcard_grouped.vcf'
     ];
 
     list.forEach(function(path) {

--- a/test/parser/vcard_grouped.json
+++ b/test/parser/vcard_grouped.json
@@ -1,0 +1,9 @@
+[
+  "vcard",
+  [
+    [ "version", {}, "text", "4.0" ],
+    [ "adr", { "type": "work" }, "text", [ "pobox", "apt", "street", "city", "state", "zipcode", "country" ] ],
+    [ "item1.adr", { "type": "home" }, "text", [ "pobox1", "apt1", "street1", "city1", "state1", "zipcode1", "country1" ] ]
+  ],
+  []
+]

--- a/test/parser/vcard_grouped.vcf
+++ b/test/parser/vcard_grouped.vcf
@@ -1,0 +1,5 @@
+BEGIN:VCARD
+VERSION:4.0
+ADR;TYPE=work:pobox;apt;street;city;state;zipcode;country
+ITEM1.ADR;TYPE=home:pobox1;apt1;street1;city1;state1;zipcode1;country1
+END:VCARD


### PR DESCRIPTION
Property names can be prefixed with a group name. This handles these
cases so the field types are correctly set, and the data correctly
parsed.

Partially fixes mozilla-comm/ical.js#411 (second item)