### PR TITLE
Detect type="module"

### DIFF
--- a/lib/ical/helpers.js
+++ b/lib/ical/helpers.js
@@ -4,10 +4,10 @@
  * Portions Copyright (C) Philipp Kewisch, 2011-2015 */
 
 
-if ('noModule' in HTMLScriptElement.prototype) {
-  // In case ical.js is executed in a JavaScript module, strict mode is enabled
-  // and requires a global variable to be assigned explicitly to e.g. the window
-  // object.
+if (typeof window !== 'undefined' && 'noModule' in HTMLScriptElement.prototype) {
+  // In case ical.js is executed in the browser and a JavaScript module, strict
+  // mode is enabled and requires a global variable to be assigned explicitly
+  // to e.g. the window object.
   window.ICAL = {};
 }
 

--- a/lib/ical/helpers.js
+++ b/lib/ical/helpers.js
@@ -4,6 +4,13 @@
  * Portions Copyright (C) Philipp Kewisch, 2011-2015 */
 
 
+if ('noModule' in HTMLScriptElement.prototype) {
+  // In case ical.js is executed in a JavaScript module, strict mode is enabled
+  // and requires a global variable to be assigned explicitly to e.g. the window
+  // object.
+  window.ICAL = {};
+}
+
 /* istanbul ignore next */
 /* jshint ignore:start */
 if (typeof module === 'object') {


### PR DESCRIPTION
Fixes #449 

This is merely an attempt to fix the above mentioned issue. The problem with this fix this that so far it only detects if the Javascript modules feature is available in the browser. However, a developer could add a regular `<script>` tag in a browser that supports modules. Then this statement would still run.

I don't see it much of a problem though, as the added statement runs in addition to the statements below, fixing it for the problems described in the linked issue #449 