### PR TITLE
event.isRecurring() does not repeat with RECURRENCE-ID without RANGE

### DIFF
--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -286,13 +286,18 @@ class Event {
   }
 
   /**
-   * Checks if the event is recurring
+   * Checks if the event is recurring, thus has an RRULE or RDATE property, or a
+   * RECURRENCE-ID with the respective RANGE parameter.
    *
    * @return {Boolean}        True, if event is recurring
    */
   isRecurring() {
-    let comp = this.component;
-    return comp.hasProperty('rrule') || comp.hasProperty('rdate');
+    let comp = this.component, recurrenceId;
+    if (comp.hasProperty('rrule') || comp.hasProperty('rdate')) {
+      recurrenceId = comp.getFirstProperty('recurrence-id');
+      return !recurrenceId || !!recurrenceId.getParameter('range');
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Evolution creates instances of events, which contain RRULE and RECURRENCE-ID without RANGE parameter.  Since the RANGE is not THISANDFUTURE, but absent, such events do not recur.

https://gitlab.gnome.org/GNOME/evolution/-/issues/1180

Currenlty isRecurring() returns under these conditions TRUE, instead of FALSE.