### PR TITLE
Fix Stringification for Parameters with Multiple Values

### DIFF
--- a/lib/ical/stringify.js
+++ b/lib/ical/stringify.js
@@ -118,18 +118,20 @@ ICAL.stringify = (function() {
       if (params.hasOwnProperty(paramName)) {
         var multiValue = (paramName in designSet.param) && designSet.param[paramName].multiValue;
         if (multiValue && Array.isArray(value)) {
-          if (designSet.param[paramName].multiValueSeparateDQuote) {
-            multiValue = '"' + multiValue + '"';
-          }
           value = value.map(stringify._rfc6868Unescape);
+          if (designSet.param[paramName].multiValueSeparateDQuote) {
+            value = value.map(function(v) { return '"' + v + '"' });
+          }
+          value = value.map(stringify.propertyValue);
           value = stringify.multiValue(value, multiValue, "unknown", null, designSet);
         } else {
           value = stringify._rfc6868Unescape(value);
+          value = stringify.propertyValue(value);
         }
 
 
         line += ';' + paramName.toUpperCase();
-        line += '=' + stringify.propertyValue(value);
+        line += '=' + value;
       }
     }
 
@@ -222,9 +224,13 @@ ICAL.stringify = (function() {
         (helpers.unescapedIndexOf(value, ';') === -1)) {
 
       return value;
-    }
+    } else if (value.startsWith('"') &&
+               value.endsWith('"')) {
 
-    return '"' + value + '"';
+      return value;
+    } else {
+      return '"' + value + '"';
+    }
   };
 
   /**

--- a/lib/ical/stringify.js
+++ b/lib/ical/stringify.js
@@ -120,7 +120,7 @@ ICAL.stringify = (function() {
         if (multiValue && Array.isArray(value)) {
           value = value.map(stringify._rfc6868Unescape);
           if (designSet.param[paramName].multiValueSeparateDQuote) {
-            value = value.map(function(v) { return '"' + v + '"' });
+            value = value.map(function(v) { return '"' + v + '"'; });
           }
           value = value.map(stringify.propertyValue);
           value = stringify.multiValue(value, multiValue, "unknown", null, designSet);


### PR DESCRIPTION
I am currently trying to solve a problem when synchronizing contacts between nextcloud and macOS Contacts. One part of the problem seems to be that parameters with multiple values are not serialized correctly by ICAL.stringify. A phone number with multiple types (e.g. "HOME" and "VOICE") is serialized as _TEL;TYPE="HOME,VOICE:0815 1234"_, which seems to be wrong according to the specification ([https://tools.ietf.org/html/rfc2426#section-4](https://tools.ietf.org/html/rfc2426#section-4) -> _param = param-name "=" param-value *("," param-value)_). The correct serialization should be _TEL;TYPE=HOME,VOICE:0815 1234_ or _TEL;TYPE="HOME","VOICE":0815 1234_.

My changes slightly update the serialization process for exactly this type of parameters. I have also added some tests to illustrate my changes.

Another possibility to fix my problem at hand would be to update the parameter configuration for phone numbers in design.js but I think that my solution which addresses the underlying problem is more general and hopefully future-proof. 

Please let me know if my fix has any flaws or needs some further discussion!