### PR TITLE
Add declaration of ICAL var

### DIFF
--- a/lib/ical/helpers.js
+++ b/lib/ical/helpers.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Portions Copyright (C) Philipp Kewisch, 2011-2015 */
 
-
+var ICAL;
 /* istanbul ignore next */
 /* jshint ignore:start */
 if (typeof module === 'object') {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "node": ">=10"
   },
   "scripts": {
-    "test": "grunt test-node"
+    "test": "grunt test-node",
+    "prepare": "grunt"
   },
   "files": [
     "build/ical.js",


### PR DESCRIPTION
This allows the module to not crash when used from nodejs

```
ReferenceError: ICAL is not defined
```

This shouldnt cause any problems with usage in the browser

Similar to

https://github.com/mozilla-comm/ical.js/issues/449
https://github.com/mozilla-comm/ical.js/issues/329