### PR TITLE
Declare the ICAL variable at the top level

### DIFF
--- a/lib/ical/helpers.js
+++ b/lib/ical/helpers.js
@@ -6,6 +6,7 @@
 
 /* istanbul ignore next */
 /* jshint ignore:start */
+var ICAL;
 if (typeof module === 'object') {
   // CommonJS, where exports may be different each time.
   ICAL = module.exports;


### PR DESCRIPTION
This change allows ical.js to be imported as a module (which requires it to run in strict mode).

Without this, ical.js doesn't work with [Snowpack](https://www.snowpack.dev), which builds everything into JS Modules.