### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -155,14 +155,14 @@ let commonValues = {
       if (aValue.length < 7) {
         // no seconds
         // -0500
-        return aValue.substr(0, 3) +
-               aValue.substr(4, 2);
+        return aValue.slice(0, 3) +
+               aValue.slice(4, 6);
       } else {
         // seconds
         // -050000
-        return aValue.substr(0, 3) +
-               aValue.substr(4, 2) +
-               aValue.substr(7, 2);
+        return aValue.slice(0, 3) +
+               aValue.slice(4, 6) +
+               aValue.slice(7, 9);
       }
     },
 
@@ -170,14 +170,14 @@ let commonValues = {
       if (aValue.length < 6) {
         // no seconds
         // -05:00
-        return aValue.substr(0, 3) + ':' +
-               aValue.substr(3, 2);
+        return aValue.slice(0, 3) + ':' +
+               aValue.slice(3, 5);
       } else {
         // seconds
         // -05:00:00
-        return aValue.substr(0, 3) + ':' +
-               aValue.substr(3, 2) + ':' +
-               aValue.substr(5, 2);
+        return aValue.slice(0, 3) + ':' +
+               aValue.slice(3, 5) + ':' +
+               aValue.slice(5, 7);
       }
     },
 
@@ -324,9 +324,9 @@ const icalValues = extend(commonValues, {
         // This is probably a date-time, e.g. 20120901T130000Z
         return icalValues["date-time"].fromICAL(aValue);
       } else {
-        return aValue.substr(0, 4) + '-' +
-               aValue.substr(4, 2) + '-' +
-               aValue.substr(6, 2);
+        return aValue.slice(0, 4) + '-' +
+               aValue.slice(4, 6) + '-' +
+               aValue.slice(6, 8);
       }
     },
 
@@ -336,9 +336,9 @@ const icalValues = extend(commonValues, {
       let len = aValue.length;
 
       if (len == 10) {
-        return aValue.substr(0, 4) +
-               aValue.substr(5, 2) +
-               aValue.substr(8, 2);
+        return aValue.slice(0, 4) +
+               aValue.slice(5, 7) +
+               aValue.slice(8, 10);
       } else if (len >= 19) {
         return icalValues["date-time"].toICAL(aValue);
       } else {
@@ -356,12 +356,12 @@ const icalValues = extend(commonValues, {
         // This is probably a date, e.g. 20120901
         return icalValues.date.fromICAL(aValue);
       } else {
-        let result = aValue.substr(0, 4) + '-' +
-                     aValue.substr(4, 2) + '-' +
-                     aValue.substr(6, 2) + 'T' +
-                     aValue.substr(9, 2) + ':' +
-                     aValue.substr(11, 2) + ':' +
-                     aValue.substr(13, 2);
+        let result = aValue.slice(0, 4) + '-' +
+                     aValue.slice(4, 6) + '-' +
+                     aValue.slice(6, 8) + 'T' +
+                     aValue.slice(9, 11) + ':' +
+                     aValue.slice(11, 13) + ':' +
+                     aValue.slice(13, 15);
 
         if (aValue[15] && aValue[15] === 'Z') {
           result += 'Z';
@@ -379,14 +379,14 @@ const icalValues = extend(commonValues, {
       if (len == 10 && !design.strict) {
         return icalValues.date.toICAL(aValue);
       } else if (len >= 19) {
-        let result = aValue.substr(0, 4) +
-                     aValue.substr(5, 2) +
+        let result = aValue.slice(0, 4) +
+                     aValue.slice(5, 7) +
                      // grab the (DDTHH) segment
-                     aValue.substr(8, 5) +
+                     aValue.slice(8, 13) +
                      // MM
-                     aValue.substr(14, 2) +
+                     aValue.slice(14, 16) +
                      // SS
-                     aValue.substr(17, 2);
+                     aValue.slice(17, 19);
 
         if (aValue[19] && aValue[19] === 'Z') {
           result += 'Z';
@@ -480,7 +480,7 @@ const icalValues = extend(commonValues, {
         }
         str += k.toUpperCase() + "=" + val + ";";
       }
-      return str.substr(0, str.length - 1);
+      return str.slice(0, Math.max(0, str.length - 1));
     },
 
     decorate: function decorate(aValue) {
@@ -502,9 +502,9 @@ const icalValues = extend(commonValues, {
       }
 
       // HH::MM::SSZ?
-      let result = aValue.substr(0, 2) + ':' +
-                   aValue.substr(2, 2) + ':' +
-                   aValue.substr(4, 2);
+      let result = aValue.slice(0, 2) + ':' +
+                   aValue.slice(2, 4) + ':' +
+                   aValue.slice(4, 6);
 
       if (aValue[6] === 'Z') {
         result += 'Z';
@@ -521,9 +521,9 @@ const icalValues = extend(commonValues, {
         return aValue;
       }
 
-      let result = aValue.substr(0, 2) +
-                   aValue.substr(3, 2) +
-                   aValue.substr(6, 2);
+      let result = aValue.slice(0, 2) +
+                   aValue.slice(3, 5) +
+                   aValue.slice(6, 8);
 
       if (aValue[8] === 'Z') {
         result += 'Z';
@@ -611,7 +611,7 @@ const vcardValues = extend(commonValues, {
       if (aValue.length == 8) {
         return icalValues.date.fromICAL(aValue);
       } else if (aValue[0] == '-' && aValue.length == 6) {
-        return aValue.substr(0, 4) + '-' + aValue.substr(4);
+        return aValue.slice(0, 4) + '-' + aValue.slice(4);
       } else {
         return aValue;
       }
@@ -620,7 +620,7 @@ const vcardValues = extend(commonValues, {
       if (aValue.length == 10) {
         return icalValues.date.toICAL(aValue);
       } else if (aValue[0] == '-' && aValue.length == 7) {
-        return aValue.substr(0, 4) + aValue.substr(5);
+        return aValue.slice(0, 4) + aValue.slice(5);
       } else {
         return aValue;
       }
@@ -641,17 +641,17 @@ const vcardValues = extend(commonValues, {
       //console.log("SPLIT: ",splitzone);
 
       if (value.length == 6) {
-        value = value.substr(0, 2) + ':' +
-                value.substr(2, 2) + ':' +
-                value.substr(4, 2);
+        value = value.slice(0, 2) + ':' +
+                value.slice(2, 4) + ':' +
+                value.slice(4, 6);
       } else if (value.length == 4 && value[0] != '-') {
-        value = value.substr(0, 2) + ':' + value.substr(2, 2);
+        value = value.slice(0, 2) + ':' + value.slice(2, 4);
       } else if (value.length == 5) {
-        value = value.substr(0, 3) + ':' + value.substr(3, 2);
+        value = value.slice(0, 3) + ':' + value.slice(3, 5);
       }
 
       if (zone.length == 5 && (zone[0] == '-' || zone[0] == '+')) {
-        zone = zone.substr(0, 3) + ':' + zone.substr(3);
+        zone = zone.slice(0, 3) + ':' + zone.slice(3);
       }
 
       return value + zone;
@@ -662,17 +662,17 @@ const vcardValues = extend(commonValues, {
       let zone = splitzone[0], value = splitzone[1];
 
       if (value.length == 8) {
-        value = value.substr(0, 2) +
-                value.substr(3, 2) +
-                value.substr(6, 2);
+        value = value.slice(0, 2) +
+                value.slice(3, 5) +
+                value.slice(6, 8);
       } else if (value.length == 5 && value[0] != '-') {
-        value = value.substr(0, 2) + value.substr(3, 2);
+        value = value.slice(0, 2) + value.slice(3, 5);
       } else if (value.length == 6) {
-        value = value.substr(0, 3) + value.substr(4, 2);
+        value = value.slice(0, 3) + value.slice(4, 6);
       }
 
       if (zone.length == 6 && (zone[0] == '-' || zone[0] == '+')) {
-        zone = zone.substr(0, 3) + zone.substr(4);
+        zone = zone.slice(0, 3) + zone.slice(4);
       }
 
       return value + zone;
@@ -686,10 +686,10 @@ const vcardValues = extend(commonValues, {
 
       if (aValue[lastChar] == 'Z') {
         zone = aValue[lastChar];
-        value = aValue.substr(0, lastChar);
+        value = aValue.slice(0, Math.max(0, lastChar));
       } else if (aValue.length > 6 && (sign == '-' || sign == '+')) {
-        zone = aValue.substr(signChar);
-        value = aValue.substr(0, signChar);
+        zone = aValue.slice(signChar);
+        value = aValue.slice(0, Math.max(0, signChar));
       } else {
         zone = "";
         value = aValue;
@@ -808,11 +808,11 @@ let vcard3Values = extend(commonValues, {
   vcard: icalValues.text,
   "utc-offset": {
     toICAL: function(aValue) {
-      return aValue.substr(0, 7);
+      return aValue.slice(0, 7);
     },
 
     fromICAL: function(aValue) {
-      return aValue.substr(0, 7);
+      return aValue.slice(0, 7);
     },
 
     decorate: function(aValue) {

--- a/lib/ical/duration.js
+++ b/lib/ical/duration.js
@@ -50,8 +50,8 @@ class Duration {
 
     while ((pos = aStr.search(DURATION_LETTERS)) !== -1) {
       let type = aStr[pos];
-      let numeric = aStr.substr(0, pos);
-      aStr = aStr.substr(pos + 1);
+      let numeric = aStr.slice(0, Math.max(0, pos));
+      aStr = aStr.slice(pos + 1);
 
       chunks += parseDurationChunk(type, numeric, dict);
     }

--- a/lib/ical/helpers.js
+++ b/lib/ical/helpers.js
@@ -243,12 +243,12 @@ export function foldline(aLine) {
     if (line_length < ICALmodule.foldLength + 1)
       pos += cp > 65535 ? 2 : 1;
     else {
-      result += ICALmodule.newLineChar + " " + line.substring(0, pos);
-      line = line.substring(pos);
+      result += ICALmodule.newLineChar + " " + line.slice(0, Math.max(0, pos));
+      line = line.slice(Math.max(0, pos));
       pos = line_length = 0;
     }
   }
-  return result.substr(ICALmodule.newLineChar.length + 1);
+  return result.slice(ICALmodule.newLineChar.length + 1);
 }
 
 /**

--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -173,23 +173,23 @@ parse._handleContentLine = function(line, state) {
 
   let parsedParams;
   if (paramPos !== -1) {
-    name = line.substring(0, paramPos).toLowerCase();
-    parsedParams = parse._parseParameters(line.substring(paramPos), 0, state.designSet);
+    name = line.slice(0, Math.max(0, paramPos)).toLowerCase();
+    parsedParams = parse._parseParameters(line.slice(Math.max(0, paramPos)), 0, state.designSet);
     if (parsedParams[2] == -1) {
       throw new ParserError("Invalid parameters in '" + line + "'");
     }
     params = parsedParams[0];
     lastParamIndex = parsedParams[1].length + parsedParams[2] + paramPos;
     if ((lastValuePos =
-      line.substring(lastParamIndex).indexOf(VALUE_DELIMITER)) !== -1) {
-      value = line.substring(lastParamIndex + lastValuePos + 1);
+      line.slice(Math.max(0, lastParamIndex)).indexOf(VALUE_DELIMITER)) !== -1) {
+      value = line.slice(Math.max(0, lastParamIndex + lastValuePos + 1));
     } else {
       throw new ParserError("Missing parameter value in '" + line + "'");
     }
   } else if (valuePos !== -1) {
     // without parmeters (BEGIN:VCAENDAR, CLASS:PUBLIC)
-    name = line.substring(0, valuePos).toLowerCase();
-    value = line.substring(valuePos + 1);
+    name = line.slice(0, Math.max(0, valuePos)).toLowerCase();
+    value = line.slice(Math.max(0, valuePos + 1));
 
     if (name === 'begin') {
       let newComponent = [value.toLowerCase(), [], []];
@@ -346,7 +346,7 @@ parse._parseParameters = function(line, start, designSet) {
   while ((pos !== false) &&
          (pos = unescapedIndexOf(line, delim, pos + 1)) !== -1) {
 
-    name = line.substr(lastParam + 1, pos - lastParam - 1);
+    name = line.slice(lastParam + 1, pos);
     if (name.length == 0) {
       throw new ParserError("Empty parameter name in '" + line + "'");
     }
@@ -386,7 +386,7 @@ parse._parseParameters = function(line, start, designSet) {
           'invalid line (no matching double quote) "' + line + '"'
         );
       }
-      value = line.substr(valuePos, pos - valuePos);
+      value = line.slice(valuePos, pos);
       lastParam = unescapedIndexOf(line, PARAM_DELIMITER, pos);
       if (lastParam === -1) {
         pos = false;
@@ -414,7 +414,7 @@ parse._parseParameters = function(line, start, designSet) {
         pos = nextPos;
       }
 
-      value = line.substr(valuePos, nextPos - valuePos);
+      value = line.slice(valuePos, nextPos);
     }
 
     value = parse._rfc6868Escape(value);
@@ -480,7 +480,7 @@ parse._parseMultiValue = function(buffer, delim, type, result, innerMulti, desig
 
   // split each piece
   while ((pos = unescapedIndexOf(buffer, delim, lastPos)) !== -1) {
-    value = buffer.substr(lastPos, pos - lastPos);
+    value = buffer.slice(lastPos, pos);
     if (innerMulti) {
       value = parse._parseMultiValue(value, innerMulti, type, [], null, designSet, structuredValue);
     } else {
@@ -491,7 +491,7 @@ parse._parseMultiValue = function(buffer, delim, type, result, innerMulti, desig
   }
 
   // on the last piece take the rest of string
-  value = buffer.substr(lastPos);
+  value = buffer.slice(lastPos);
   if (innerMulti) {
     value = parse._parseMultiValue(value, innerMulti, type, [], null, designSet, structuredValue);
   } else {
@@ -538,18 +538,12 @@ parse._eachLine = function(buffer, callback) {
 
     if (firstChar === ' ' || firstChar === '\t') {
       // add to line
-      line += buffer.substr(
-        lastPos + 1,
-        pos - lastPos - (newlineOffset + 1)
-      );
+      line += buffer.slice(lastPos + 1, pos - newlineOffset);
     } else {
       if (line)
         callback(null, line);
       // push line
-      line = buffer.substr(
-        lastPos,
-        pos - lastPos - newlineOffset
-      );
+      line = buffer.slice(lastPos, pos - newlineOffset);
     }
 
     lastPos = pos;

--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -471,7 +471,7 @@ function parseNumericValue(type, min, max, value) {
   let result = value;
 
   if (value[0] === '+') {
-    result = value.substr(1);
+    result = value.slice(1);
   }
 
   result = strictParseInt(result);

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -120,9 +120,9 @@ class Time {
    */
   static fromStringv2(str) {
     return new Time({
-      year: parseInt(str.substr(0, 4), 10),
-      month: parseInt(str.substr(5, 2), 10),
-      day: parseInt(str.substr(8, 2), 10),
+      year: parseInt(str.slice(0, 4), 10),
+      month: parseInt(str.slice(5, 7), 10),
+      day: parseInt(str.slice(8, 10), 10),
       isDate: true
     });
   }
@@ -141,9 +141,9 @@ class Time {
     // YYYY-MM-DD
     // 2012-10-10
     return new Time({
-      year: strictParseInt(aValue.substr(0, 4)),
-      month: strictParseInt(aValue.substr(5, 2)),
-      day: strictParseInt(aValue.substr(8, 2)),
+      year: strictParseInt(aValue.slice(0, 4)),
+      month: strictParseInt(aValue.slice(5, 7)),
+      day: strictParseInt(aValue.slice(8, 10)),
       isDate: true
     });
   }
@@ -174,12 +174,12 @@ class Time {
 
     // 2012-10-10T10:10:10(Z)?
     let time = new Time({
-      year: strictParseInt(aValue.substr(0, 4)),
-      month: strictParseInt(aValue.substr(5, 2)),
-      day: strictParseInt(aValue.substr(8, 2)),
-      hour: strictParseInt(aValue.substr(11, 2)),
-      minute: strictParseInt(aValue.substr(14, 2)),
-      second: strictParseInt(aValue.substr(17, 2)),
+      year: strictParseInt(aValue.slice(0, 4)),
+      month: strictParseInt(aValue.slice(5, 7)),
+      day: strictParseInt(aValue.slice(8, 10)),
+      hour: strictParseInt(aValue.slice(11, 13)),
+      minute: strictParseInt(aValue.slice(14, 16)),
+      second: strictParseInt(aValue.slice(17, 19)),
       timezone: zone
     });
 

--- a/lib/ical/utc_offset.js
+++ b/lib/ical/utc_offset.js
@@ -25,8 +25,8 @@ class UtcOffset {
     let options = {};
     //TODO: support seconds per rfc5545 ?
     options.factor = (aString[0] === '+') ? 1 : -1;
-    options.hours = strictParseInt(aString.substr(1, 2));
-    options.minutes = strictParseInt(aString.substr(4, 2));
+    options.hours = strictParseInt(aString.slice(1, 3));
+    options.minutes = strictParseInt(aString.slice(4, 6));
 
     return new UtcOffset(options);
   }

--- a/lib/ical/vcard_time.js
+++ b/lib/ical/vcard_time.js
@@ -34,7 +34,7 @@ class VCardTime extends Time {
    */
   static fromDateAndOrTimeString(aValue, aIcalType) {
     function part(v, s, e) {
-      return v ? strictParseInt(v.substr(s, e)) : null;
+      return v ? strictParseInt(v.slice(s, s + e)) : null;
     }
     let parts = aValue.split('T');
     let dt = parts[0], tmz = parts[1];


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.