### PR TITLE
parser._handleContentLine() parsing including ^ in the parameter value

### DIFF
--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -417,7 +417,9 @@ parse._parseParameters = function(line, start, designSet) {
       value = line.slice(valuePos, nextPos);
     }
 
+    const length_before = value.length;
     value = parse._rfc6868Escape(value);
+    valuePos += length_before - value.length;
     if (multiValue) {
       let delimiter = mvdelim || multiValue;
       value = parse._parseMultiValue(value, delimiter, type, [], null, designSet);

--- a/test/parser/property_params.ics
+++ b/test/parser/property_params.ics
@@ -7,6 +7,7 @@ ATTENDEE;CN="Foo, Bar":mailto:foo3@bar
 ATTENDEE;CN="Foo; Bar":mailto:foo4@bar
 ATTENDEE;DELEGATED-TO="mailto:foo7@bar";CN="Foo, Bar":mailto:foo5@bar
 ATTENDEE;DELEGATED-TO="mailto:foo7@bar";CN="Foo; Bar":mailto:foo6@bar
+ATTENDEE;CN="^^Ж 4 <>\'^'^n:":mailto:foo9@bar
 ATTENDEE;ROLE="REQ-PARTICIPANT;foo";DELEGATED-FROM="mailto:bar@baz.com";PAR
  TSTAT=ACCEPTED;RSVP=TRUE:mailto:foo@bar.com
 X-FOO;PARAM1=VAL1:FOO;BAR

--- a/test/parser/property_params.json
+++ b/test/parser/property_params.json
@@ -61,6 +61,14 @@
     [
       "attendee",
       {
+        "cn": "^Ж 4 <>\\'\"\n:"
+      },
+      "cal-address",
+      "mailto:foo9@bar"
+    ],
+    [
+      "attendee",
+      {
         "role": "REQ-PARTICIPANT;foo",
         "delegated-from": "mailto:bar@baz.com",
         "partstat": "ACCEPTED",


### PR DESCRIPTION
Prior this change the property `ATTENDEE=CN="Ж 4 <>'^':":mailto:1@example.org` is read as:
```javascript
  jCal: [
    'attendee',
    { cn: `Ж 4 <>'":` },
    'cal-address',
    '":mailto:1@example.org'
  ]
```
The value starts with quote, which is wrong.

I do not add a test, because, among other things, [I cannot run](https://github.com/mozilla-comm/ical.js/issues/506) the existing tests.