### PR TITLE
Fix stringification of structured values with multiple newlines

### DIFF
--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -29,7 +29,7 @@ ICAL.design = (function() {
       toICAL: function(aValue, structuredEscape) {
         var regEx = toNewline;
         if (structuredEscape)
-          regEx = new RegExp(regEx.source + '|' + structuredEscape);
+          regEx = new RegExp(regEx.source + '|' + structuredEscape, regEx.flags);
         return aValue.replace(regEx, function(str) {
           switch (str) {
           case "\\":
@@ -85,7 +85,7 @@ ICAL.design = (function() {
       return value;
     }
     if (structuredEscape)
-      newline = new RegExp(newline.source + '|\\\\' + structuredEscape);
+      newline = new RegExp(newline.source + '|\\\\' + structuredEscape, newline.flags);
     return value.replace(newline, replaceNewlineReplace);
   }
 

--- a/test/stringify_test.js
+++ b/test/stringify_test.js
@@ -145,5 +145,34 @@ suite('ICAL.stringify', function() {
 
       assert.equal(ICAL.stringify.component(subject), expected);
     });
+
+    test('structured values', function() {
+      var subject = [
+        "vcard",
+        [
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "one",
+              "two",
+              "three\n\n",
+              "four\nfour\n",
+              [
+                "five",
+                "five\n\n",
+                "five\nfive\n"
+              ],
+              "six",
+              "seven"
+            ]
+          ]
+        ]
+      ];
+      var expected = "BEGIN:VCARD\r\nADR:one;two;three\\n\\n;four\\nfour\\n;five,five\\n\\n,five\\nfive\\n;six;seven\r\nEND:VCARD";
+
+      assert.equal(ICAL.stringify.component(subject), expected);
+    });
   });
 });


### PR DESCRIPTION
The creation of a new RegExp object drops the flags of the original RegExp object. In this case the flag is 'g', meaning only one match is replaced instead of all of them.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1771893 which is a bug in Thunderbird that exposes the problem.