### PR TITLE
Upstream spelling corrections from comm-central

### DIFF
--- a/lib/ical/recur_expansion.js
+++ b/lib/ical/recur_expansion.js
@@ -229,7 +229,7 @@ ICAL.RecurExpansion = (function() {
       while (true) {
         if (currentTry++ > maxTries) {
           throw new Error(
-            'max tries have occured, rule may be impossible to forfill.'
+            'max tries have occurred, rule may be impossible to fulfill.'
           );
         }
 

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -13,7 +13,7 @@ ICAL.RecurIterator = (function() {
   /**
    * @classdesc
    * An iterator for a single recurrence rule. This class usually doesn't have
-   * to be instanciated directly, the convenience method
+   * to be instantiated directly, the convenience method
    * {@link ICAL.Recur#iterator} can be used.
    *
    * @description
@@ -165,7 +165,7 @@ ICAL.RecurIterator = (function() {
     },
 
     /**
-     * Intialize the iterator
+     * Initialize the iterator
      * @private
      */
     init: function icalrecur_iterator_init() {
@@ -606,7 +606,7 @@ ICAL.RecurIterator = (function() {
         // find next date
         var next = byMonthDay[dateIdx++];
 
-        // this logic is dependant on the BYMONTHDAYS
+        // this logic is dependent on the BYMONTHDAYS
         // being in order (which is done by #normalizeByMonthDayRules)
         if (next >= date) {
           // if the next month day is in the future jump to it.

--- a/lib/ical/stringify.js
+++ b/lib/ical/stringify.js
@@ -114,7 +114,7 @@ ICAL.stringify = (function() {
 
     var groupName = params.group;
     var line;
-    if (groupName && designSet.propertyGroups) {
+    if (designSet.propertyGroups && groupName) {
       line = groupName.toUpperCase() + "." + name;
     } else {
       line = name;

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -599,7 +599,7 @@
      * the relative difference between two time objects excluding their
      * timezone differences.
      *
-     * @param {ICAL.Time} aDate     The date to substract
+     * @param {ICAL.Time} aDate     The date to subtract
      * @return {ICAL.Duration}      The difference as a duration
      */
     subtractDate: function icaltime_subtract(aDate) {

--- a/lib/ical/timezone.js
+++ b/lib/ical/timezone.js
@@ -524,6 +524,6 @@
   };
 
   ICAL.Timezone._minimumExpansionYear = -1;
-  ICAL.Timezone.MAX_YEAR = 2035; // TODO this is because of time_t, which we don't need. Still usefull?
+  ICAL.Timezone.MAX_YEAR = 2035; // TODO this is because of time_t, which we don't need. Still useful?
   ICAL.Timezone.EXTRA_COVERAGE = 5;
 })();


### PR DESCRIPTION
Somebody ran codespell at some point, this patch upstreams the corrections so we can stop working around them.