### PR TITLE
Use native Date constructor in Time.fromUnixTime

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -863,15 +863,19 @@
      */
     fromUnixTime: function fromUnixTime(seconds) {
       this.zone = ICAL.Timezone.utcTimezone;
-      var epoch = ICAL.Time.epochTime.clone();
-      epoch.adjust(0, 0, 0, seconds);
-
-      this.year = epoch.year;
-      this.month = epoch.month;
-      this.day = epoch.day;
-      this.hour = epoch.hour;
-      this.minute = epoch.minute;
-      this.second = Math.floor(epoch.second);
+      var date = new Date(seconds * 1000);
+      this.year = date.getUTCFullYear();
+      this.month = date.getUTCMonth() + 1;
+      this.day = date.getUTCDate();
+      if (this._time.isDate) {
+        this.hour = 0;
+        this.minute = 0;
+        this.second = 0;
+      } else {
+        this.hour = date.getUTCHours();
+        this.minute = date.getUTCMinutes();
+        this.second = date.getUTCSeconds();
+      }
 
       this._cachedUnixTime = null;
     },

--- a/test/performance/time_test.js
+++ b/test/performance/time_test.js
@@ -70,6 +70,10 @@ perfCompareSuite('ICAL.Time', function(perf, ICAL) {
     _time.toUnixTime();
   });
 
+  perf.test('fromUnixTime', function() {
+    _time.fromUnixTime(1234567890);
+  });
+
   perf.test('dayOfWeek', function() {
     _time.dayOfWeek();
   });
@@ -77,5 +81,4 @@ perfCompareSuite('ICAL.Time', function(perf, ICAL) {
   perf.test('weekNumber', function() {
     _time.weekNumber();
   });
-
 });


### PR DESCRIPTION
This is roughly 100 times faster on my machine.