### PR TITLE
Fix recurrence iteration where there is a BYMONTHDAY rule greater than the number of days in the start month.

### DIFF
--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -311,14 +311,29 @@ class RecurIterator {
       if (this.last.day > daysInMonth || this.last.day == 0) {
         throw new Error("Malformed values in BYDAY part");
       }
-    } else if (this.has_by_data("BYMONTHDAY") && dayOffset < 0) {
-      // Attempting to access `this.last.day` will cause the date to be normalised and
-      // not return a negative value. We keep the value in a separate variable instead.
+    } else if (this.has_by_data("BYMONTHDAY")) {
+      // Attempting to access `this.last.day` will cause the date to be normalised.
+      // So it will never be a negative value or more than the number of days in the month.
+      // We keep the value in a separate variable instead.
 
-      // Now change the day value so that normalisation won't change the month.
+      // Change the day value so that normalisation won't change the month.
       this.last.day = 1;
       let daysInMonth = Time.daysInMonth(this.last.month, this.last.year);
-      this.last.day = daysInMonth + dayOffset + 1;
+
+      if (dayOffset < 0) {
+        // A negative value represents days before the end of the month.
+        this.last.day = daysInMonth + dayOffset + 1;
+      } else if (this.by_data.BYMONTHDAY[0] > daysInMonth) {
+        // There's no occurrence in this month, find the next valid month.
+        // The longest possible sequence of skipped months is February-April-June,
+        // so we might need to call next_month up to three times.
+        if (!this.next_month() && !this.next_month() && !this.next_month()) {
+          throw new Error("No possible occurrences");
+        }
+      } else {
+        // Otherwise, reset the day.
+        this.last.day = dayOffset;
+      }
     }
   }
 

--- a/test/recur_iterator_test.js
+++ b/test/recur_iterator_test.js
@@ -143,6 +143,12 @@ suite('recur_iterator', function() {
 
       let start = ICAL.Time.fromString(options.dtStart);
       let recur = ICAL.Recur.fromString(ruleString);
+      if (options.throws) {
+        assert.throws(function() {
+          recur.iterator(start);
+        });
+        return;
+      }
       let iterator = recur.iterator(start);
 
       let inc = 0;
@@ -641,6 +647,48 @@ suite('recur_iterator', function() {
           '2023-06-29T08:00:00',
           '2023-09-29T08:00:00',
         ]
+      });
+
+      // 31st day of the month, every two months. Starting on a month that has 31 days.
+      testRRULE('FREQ=MONTHLY;INTERVAL=2;BYMONTHDAY=31', {
+        dtStart: '2022-07-01T08:00:00',
+        dates: [
+          '2022-07-31T08:00:00',
+          '2023-01-31T08:00:00',
+          '2023-03-31T08:00:00',
+          '2023-05-31T08:00:00',
+          '2023-07-31T08:00:00',
+        ]
+      });
+
+      // 31st day of the month, every two months. Starting on a month that has 30 days.
+      testRRULE('FREQ=MONTHLY;INTERVAL=2;BYMONTHDAY=31', {
+        dtStart: '2022-06-01T08:00:00',
+        dates: [
+          '2022-08-31T08:00:00',
+          '2022-10-31T08:00:00',
+          '2022-12-31T08:00:00',
+          '2023-08-31T08:00:00',
+          '2023-10-31T08:00:00',
+        ]
+      });
+
+      // 31st day of the month, every two months. Starting with three invalid months.
+      testRRULE('FREQ=MONTHLY;INTERVAL=2;BYMONTHDAY=31', {
+        dtStart: '2022-02-01T08:00:00',
+        dates: [
+          '2022-08-31T08:00:00',
+          '2022-10-31T08:00:00',
+          '2022-12-31T08:00:00',
+          '2023-08-31T08:00:00',
+          '2023-10-31T08:00:00',
+        ]
+      });
+
+      // Invalid rule. There's never a 31st of Feburary, check that this fails.
+      testRRULE('FREQ=MONTHLY;INTERVAL=12;BYMONTHDAY=31', {
+        dtStart: '2022-02-01T08:00:00',
+        throws: true,
       });
 
       // monthly + by month


### PR DESCRIPTION
This gets tricky. If the starting month doesn't have an occurrence (e.g. June has no 31st day), we need to find the next month that does. It's possible to have a sequence of 3 months without as 31st at an interval of 2 (February, April, June) so we might need to look for the next month three times.

(In the Gregorian calendar it IS possible to miss 7 occurrences if the interval is 12 and the start is a February late in a century, but that's absurd and I will be dead by then.)