### PR TITLE
recur_expansion.js: fix iterator with RDATE-only recurrence

### DIFF
--- a/lib/ical/recur_expansion.js
+++ b/lib/ical/recur_expansion.js
@@ -121,7 +121,7 @@ ICAL.RecurExpansion = (function() {
      * @type {Number}
      * @private
      */
-    ruleDateInc: 0,
+    ruleDateInc: -1,
 
     /**
      * Current position in exDates array
@@ -241,6 +241,14 @@ ICAL.RecurExpansion = (function() {
         // _after_ we choose a value this should be
         // the only spot where we need to worry about the
         // end of events.
+        if (this.ruleDateInc == -1) {
+            this._nextRuleDay();
+            if (!iter) {
+              // on the first iteration return DTSTART
+              return this.last;
+            }
+        }
+
         if (!next && !iter) {
           // there are no more iterators or rdates
           this.complete = true;
@@ -278,7 +286,7 @@ ICAL.RecurExpansion = (function() {
         }
 
         //XXX: The spec states that after we resolve the final
-        //     list of dates we execute exdate this seems somewhat counter
+        //     list of dates we execute exdate.  This seems somewhat counter
         //     intuitive to what I have seen most servers do so for now
         //     I exclude based on the original date not the one that may
         //     have been modified by the exception.
@@ -384,15 +392,14 @@ ICAL.RecurExpansion = (function() {
 
           this.ruleDateInc = 0;
           this.last = this.ruleDates[0].clone();
+          this.ruleDate = this.ruleDates[0];
         } else {
           this.ruleDateInc = ICAL.helpers.binsearchInsert(
             this.ruleDates,
             this.last,
             compareTime
-          );
+          ) - 1;
         }
-
-        this.ruleDate = this.ruleDates[this.ruleDateInc];
       }
 
       if (component.hasProperty('rrule')) {

--- a/test/recur_expansion_test.js
+++ b/test/recur_expansion_test.js
@@ -61,6 +61,29 @@ suite('recur_expansion', function() {
       }, ".ruleIterators or .component must be given");
     });
 
+    test('only rdate without rrule', function() {
+      var component = primary.component.toJSON();
+      component = new ICAL.Component(component);
+      component.removeAllProperties('rrule');
+
+      var subject = new ICAL.RecurExpansion({
+        component,
+        dtstart: primary.startDate
+      });
+      var expected = [
+        new Date(2012, 09, 02, 10),
+        new Date(2012, 10, 05, 10),
+        new Date(2012, 10, 10, 10),
+        new Date(2012, 10, 30, 10)
+      ], dates = [], next;
+
+      while (next = subject.next() ) {
+        dates.push(next.toJSDate());
+      }
+
+      assert.deepEqual(dates, expected);
+    });
+
     test('default', function() {
       var dtstart = ICAL.Time.fromData({
         year: 2012,


### PR DESCRIPTION
When iterating with
```javascript
  e is an event-component
  if (e.isRecurring() {
     let i = e.iterator();
     while (n = i.next()) {
       o = g.getOccurrenceDetails(obj)
       …
     }
  }
```
on the first iteration the DTSTART instance shall be returned.  It is returned, when there is RRULE.  In the lack of this change, on the first iteration, when RDATE is present without RRULE, the first RDATE instance is returned.

@darktrojan  how does Thunderbird handle VEVENTS with RDATE but without RRULE.  These are presented correct in the UI.  But the instances cannot be obtained by getting an iteratior of the event and then calling .next().  The reason is, that the very first iteration skips then the DTSTART-instance.  The DTSTART instance is not skipped by the iterator.next() when the VEVENT has RRULE. 

