### PR TITLE
stringify: do not use unescapedIndexOf in property parameters

### DIFF
--- a/lib/ical/stringify.js
+++ b/lib/ical/stringify.js
@@ -4,7 +4,7 @@
  * Portions Copyright (C) Philipp Kewisch */
 
 import design from "./design.js";
-import { foldline, unescapedIndexOf } from "./helpers.js";
+import { foldline } from "./helpers.js";
 
 const LINE_ENDING = '\r\n';
 const DEFAULT_VALUE_TYPE = 'unknown';
@@ -127,9 +127,8 @@ stringify.property = function(property, designSet, noFold) {
       value = stringify._rfc6868Unescape(value);
     }
 
-
     line += ';' + paramName.toUpperCase();
-    line += '=' + stringify.propertyValue(value);
+    line += '=' + stringify.propertyParameterValue(value);
   }
 
   if (property.length === 3) {
@@ -206,15 +205,15 @@ stringify.property = function(property, designSet, noFold) {
  * If any of the above are present the result is wrapped
  * in double quotes.
  *
- * @function ICAL.stringify.propertyValue
+ * @function ICAL.stringify.propertyParameterValue
  * @param {String} value      Raw property value
  * @return {String}           Given or escaped value when needed
  */
-stringify.propertyValue = function(value) {
-
-  if ((unescapedIndexOf(value, ',') === -1) &&
-      (unescapedIndexOf(value, ':') === -1) &&
-      (unescapedIndexOf(value, ';') === -1)) {
+stringify.propertyParameterValue = function(value, force) {
+  if (!force &&
+      (value.indexOf(',') === -1) &&
+      (value.indexOf(':') === -1) &&
+      (value.indexOf(';') === -1)) {
 
     return value;
   }

--- a/test/stringify_test.js
+++ b/test/stringify_test.js
@@ -80,6 +80,13 @@ suite('ICAL.stringify', function() {
       delete ICAL.design.defaultSet.property.custom;
     });
 
+    test('stringify property value containing "escaped" ; , :', function() {
+      let subject = new ICAL.Property('attendee');
+      subject.setParameter('cn', 'X\\:');
+      subject.setValue('mailto:id');
+      assert.equal(subject.toICALString(), 'ATTENDEE;CN="X\\:":mailto:id');
+    });
+
     test('rfc6868 roundtrip', function() {
       let subject = new ICAL.Property('attendee');
       let input = "caret ^ dquote \" newline \n end";


### PR DESCRIPTION
… as \ is no escape character there.

When the propery parameter contains :, then it must be quoted, the colon cannot be escaped.

As the function stringify.propertyValue in fact stringifies property parameter values, it is renamed accordingly.