### PR TITLE
parse._parsedParameters: do not use helpers.unescapedIndexOf()

### DIFF
--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -344,7 +344,7 @@ parse._parseParameters = function(line, start, designSet) {
   // then increment pos to find next ;
 
   while ((pos !== false) &&
-         (pos = unescapedIndexOf(line, delim, pos + 1)) !== -1) {
+         (pos = line.indexOf(delim, pos + 1)) !== -1) {
 
     name = line.slice(lastParam + 1, pos);
     if (name.length == 0) {
@@ -370,12 +370,12 @@ parse._parseParameters = function(line, start, designSet) {
     let nextChar = line[pos + 1];
     if (nextChar === '"') {
       valuePos = pos + 2;
-      pos = unescapedIndexOf(line, '"', valuePos);
+      pos = line.indexOf('"', valuePos);
       if (multiValue && pos != -1) {
           let extendedValue = true;
           while (extendedValue) {
             if (line[pos + 1] == multiValue && line[pos + 2] == '"') {
-              pos = unescapedIndexOf(line, '"', pos + 3);
+              pos = line.indexOf('"', pos + 3);
             } else {
               extendedValue = false;
             }
@@ -387,8 +387,8 @@ parse._parseParameters = function(line, start, designSet) {
         );
       }
       value = line.slice(valuePos, pos);
-      lastParam = unescapedIndexOf(line, PARAM_DELIMITER, pos);
-      let propValuePos = unescapedIndexOf(line, VALUE_DELIMITER, pos);
+      lastParam = line.indexOf(PARAM_DELIMITER, pos);
+      let propValuePos = line.indexOf(VALUE_DELIMITER, pos);
       // if either no next parameter or delimeter in property value, let's stop here
       if (lastParam === -1 || (propValuePos !== -1 && lastParam > propValuePos)) {
         pos = false;
@@ -397,8 +397,8 @@ parse._parseParameters = function(line, start, designSet) {
       valuePos = pos + 1;
 
       // move to next ";"
-      let nextPos = unescapedIndexOf(line, PARAM_DELIMITER, valuePos);
-      let propValuePos = unescapedIndexOf(line, VALUE_DELIMITER, valuePos);
+      let nextPos = line.indexOf(PARAM_DELIMITER, valuePos);
+      let propValuePos = line.indexOf(VALUE_DELIMITER, valuePos);
       if (propValuePos !== -1 && nextPos > propValuePos) {
         // this is a delimiter in the property value, let's stop here
         nextPos = propValuePos;

--- a/test/parser/property_params.ics
+++ b/test/parser/property_params.ics
@@ -9,6 +9,8 @@ ATTENDEE;DELEGATED-TO="mailto:foo7@bar";CN="Foo, Bar":mailto:foo5@bar
 ATTENDEE;DELEGATED-TO="mailto:foo7@bar";CN="Foo; Bar":mailto:foo6@bar
 ATTENDEE;ROLE="REQ-PARTICIPANT;foo";DELEGATED-FROM="mailto:bar@baz.com";PAR
  TSTAT=ACCEPTED;RSVP=TRUE:mailto:foo@bar.com
+ATTENDEE;CN=X\:mailto:x@example.org
+ATTENDEE;CN="Y\":mailto:y@example.org
 X-FOO;PARAM1=VAL1:FOO;BAR
 X-FOO2;PARAM1=VAL1;PARAM2=VAL2:FOO;BAR
 X-BAR;PARAM1="VAL1:FOO":BAZ;BAR

--- a/test/parser/property_params.json
+++ b/test/parser/property_params.json
@@ -70,6 +70,22 @@
       "mailto:foo@bar.com"
     ],
     [
+      "attendee",
+      {
+        "cn": "X\\"
+      },
+      "cal-address",
+      "mailto:x@example.org"
+    ],
+    [
+      "attendee",
+      {
+        "cn": "Y\\"
+      },
+      "cal-address",
+      "mailto:y@example.org"
+    ],
+    [
       "x-foo",
       {
         "param1": "VAL1"


### PR DESCRIPTION
iCalendar and vCard parameters do not use `\` as escape character in the property parameter values, hence `cn="\"X"` is not a quote X, but invalid. The proper escape character is `^` per RFC 6868.  This change replaces helpers.unescapedIndexOf(x,…) with x.indexOf(…) in order not to count `\` as escape character.