### PR TITLE
Try again before avoiding death by recursion

### DIFF
--- a/lib/ical/recur.js
+++ b/lib/ical/recur.js
@@ -103,12 +103,13 @@ class Recur {
 
       if (ucname in partDesign) {
         let partArr = value.split(',');
-        let partArrIdx = 0;
-        let partArrLen = partArr.length;
+        let partSet = new Set();
 
-        for (; partArrIdx < partArrLen; partArrIdx++) {
-          partArr[partArrIdx] = partDesign[ucname](partArr[partArrIdx]);
+        for (let part of partArr) {
+          partSet.add(partDesign[ucname](part));
         }
+        partArr = [...partSet];
+
         dict[name] = (partArr.length == 1 ? partArr[0] : partArr);
       } else if (ucname in optionDesign) {
         optionDesign[ucname](value, dict, fmtIcal);

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -326,7 +326,7 @@ class RecurIterator {
    * Retrieve the next occurrence from the iterator.
    * @return {ICAL.Time}
    */
-  next() {
+  next(again = false) {
     let before = (this.last ? this.last.clone() : null);
 
     if ((this.rule.count && this.occurrence_number >= this.rule.count) ||
@@ -380,10 +380,11 @@ class RecurIterator {
              this.last.compare(this.dtstart) < 0 ||
              !valid);
 
-    // TODO is this valid?
     if (this.last.compare(before) == 0) {
-      throw new Error("Same occurrence found twice, protecting " +
-                      "you from death by recursion");
+      if (again) {
+        throw new Error("Same occurrence found twice, protecting you from death by recursion");
+      }
+      this.next(true);
     }
 
     if (this.rule.until && this.last.compare(this.rule.until) > 0) {

--- a/test/recur_iterator_test.js
+++ b/test/recur_iterator_test.js
@@ -607,6 +607,35 @@ suite('recur_iterator', function() {
         ]
       });
 
+      // Last day and 31st day of the month. The last day could be the 31st,
+      // and this shouldn't throw an error.
+      testRRULE('FREQ=MONTHLY;BYMONTHDAY=-1,31', {
+        dtStart: '2022-01-01T08:00:00',
+        dates: [
+          '2022-01-31T08:00:00',
+          '2022-02-28T08:00:00',
+          '2022-03-31T08:00:00',
+          '2022-04-30T08:00:00',
+          '2022-05-31T08:00:00',
+          '2022-06-30T08:00:00'
+        ]
+      });
+
+      // 31st day of the month, specified more than once. The repeated values
+      // should be collapsed to one.
+      testRRULE('FREQ=MONTHLY;BYMONTHDAY=31,31,31,31', {
+        dtStart: '2022-01-01T08:00:00',
+        dates: [
+          '2022-01-31T08:00:00',
+          '2022-03-31T08:00:00',
+          '2022-05-31T08:00:00',
+          '2022-07-31T08:00:00',
+          '2022-08-31T08:00:00',
+          '2022-10-31T08:00:00',
+          '2022-12-31T08:00:00',
+        ]
+      });
+
       // Last day of the month, monthly.
       testRRULE('FREQ=MONTHLY;BYMONTHDAY=-1', {
         dtStart: '2015-01-01T08:00:00',


### PR DESCRIPTION
I'm not sure about this. I've made it so that multiple occurrences at the same time are ignored.

But that's not what libical does (at least the ancient version that ships with Thunderbird). That gives every occurrence, even if it's the same as the previous one. In the first test case I added, the expected output would be:

```
2022-01-31T08:00:00
2022-01-31T08:00:00 <-- same as before
2022-02-28T08:00:00
2022-03-31T08:00:00
2022-03-31T08:00:00 <-- same as before
2022-04-30T08:00:00
2022-05-31T08:00:00
2022-05-31T08:00:00 <-- same as before
2022-06-30T08:00:00
```

The same behaviour can be replicated here easily, just by pulling out the "death by recursion" error completely.

Does anyone have insight into which is the right thing to do here?