### PR TITLE
package.json:exports: include leading ./

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "ghpages": "npm run jsdoc && npm run validator"
   },
   "exports": {
-    "import": "dist/ical.min.js",
-    "require": "dist/ical.es5.min.cjs"
+    "import": "./dist/ical.min.js",
+    "require": "./dist/ical.es5.min.cjs"
   },
   "files": [
     "dist/ical.js",


### PR DESCRIPTION
https://nodejs.org/api/packages.html#exports contains «All paths defined in the `"exports"` must be relative file URLs starting with `./`.»

Without leading `./` on `"import"`-ing ical.js NodeJS prints:
```
node:internal/errors:484
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "dist/ical.min.js" defined in the package config some_path/node_modules/ical.js/package.json imported from some_path/src/zzz.js; targets must start with "./"
    at new NodeError (node:internal/errors:393:5)
    at throwInvalidPackageTarget (node:internal/modules/esm/resolve:386:9)
    at resolvePackageTargetString (node:internal/modules/esm/resolve:429:5)
    at resolvePackageTarget (node:internal/modules/esm/resolve:493:12)
    at resolvePackageTarget (node:internal/modules/esm/resolve:542:31)
    at packageExportsResolve (node:internal/modules/esm/resolve:606:27)
    at packageResolve (node:internal/modules/esm/resolve:843:14)
    at moduleResolve (node:internal/modules/esm/resolve:909:20)
    at defaultResolve (node:internal/modules/esm/resolve:1124:11)
    at nextResolve (node:internal/modules/esm/loader:163:28) {
  code: 'ERR_INVALID_PACKAGE_TARGET'
}

Node.js v18.12.0
```