### PR TITLE
Fix use of non-existent time zone in fromDateTimeString()

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -176,7 +176,7 @@ class Time {
         if (prop.parent.name === 'standard' || prop.parent.name === 'daylight') {
           // Per RFC 5545 3.8.2.4 and 3.8.2.2, start/end date-times within
           // these components MUST be specified in local time.
-          zone = Timezone.floating;
+          zone = Timezone.localTimezone;
         } else if (zoneId) {
           // If the desired time zone is defined within the component tree,
           // fetch its definition and prefer that.


### PR DESCRIPTION
`Timezone.localTimezone` is the correct identifier here, not `Timezone.floating`. The version in trunk will succeed when `tzid` isn't set on the property (which, when we're defining a time zone, they shouldn't be), as we'll then fall back to `Timezone.localTimezone` when we instantiate the `Time` object. However, if `tzid` were set on the date prop, we could get some odd behavior.