### PR TITLE
Simplify lazy initialisation of TimezoneService.

### DIFF
--- a/lib/ical/timezone_service.js
+++ b/lib/ical/timezone_service.js
@@ -6,26 +6,7 @@
 import Timezone from "./timezone.js";
 import Component from "./component.js";
 
-let zones = {
-};
-
-function lazyZone(name) {
-  return {
-    configurable: true,
-    enumerable: true,
-    get: function() {
-      delete this[name];
-      TimezoneService.reset();
-      return this[name];
-    }
-  };
-}
-
-Object.defineProperties(zones, {
-  Z: lazyZone("Z"),
-  UTC: lazyZone("UTC"),
-  GMT: lazyZone("GMT"),
-});
+let zones = null;
 
 /**
  * @classdesc
@@ -38,6 +19,10 @@ Object.defineProperties(zones, {
  */
 const TimezoneService = {
   get count() {
+    if (zones === null) {
+      return 0;
+    }
+
     return Object.keys(zones).length;
   },
 
@@ -57,6 +42,10 @@ const TimezoneService = {
    * @return {Boolean}        False, when not present
    */
   has: function(tzid) {
+    if (zones === null) {
+      return false;
+    }
+
     return !!zones[tzid];
   },
 
@@ -67,6 +56,10 @@ const TimezoneService = {
    * @return {?ICAL.Timezone} The timezone, or null if not found
    */
   get: function(tzid) {
+    if (zones === null) {
+      this.reset();
+    }
+
     return zones[tzid];
   },
 
@@ -80,6 +73,10 @@ const TimezoneService = {
    *        The initialized zone or vtimezone.
    */
   register: function(name, timezone) {
+    if (zones === null) {
+      this.reset();
+    }
+
     if (name instanceof Component) {
       if (name.name === 'vtimezone') {
         timezone = new Timezone(name);
@@ -101,6 +98,10 @@ const TimezoneService = {
    * @return {?ICAL.Timezone} The removed timezone, or null if not registered
    */
   remove: function(tzid) {
+    if (zones === null) {
+      return null;
+    }
+
     return (delete zones[tzid]);
   }
 };


### PR DESCRIPTION
It appears the current way of bootstrapping the core zones exists because TimezoneService's position among the modules means we can't call reset immediately.

Something seem to not work right and leads to Time.epochTime being in the floating time zone instead of UTC. At least when run in Thunderbird, I'm not sure if it always happens. My patch just creates the zones on first use.