### PR TITLE
stringify: do not use unescapedIndexOf in property parameters

### DIFF
--- a/lib/ical/stringify.js
+++ b/lib/ical/stringify.js
@@ -4,7 +4,7 @@
  * Portions Copyright (C) Philipp Kewisch */
 
 import design from "./design.js";
-import { foldline, unescapedIndexOf } from "./helpers.js";
+import { foldline } from "./helpers.js";
 
 const LINE_ENDING = '\r\n';
 const DEFAULT_VALUE_TYPE = 'unknown';
@@ -131,7 +131,6 @@ stringify.property = function(property, designSet, noFold) {
       value = stringify.paramPropertyValue(value);
     }
 
-
     line += ';' + paramName.toUpperCase() + '=' + value;
   }
 
@@ -216,9 +215,9 @@ stringify.property = function(property, designSet, noFold) {
  */
 stringify.paramPropertyValue = function(value, force) {
   if (!force &&
-      (unescapedIndexOf(value, ',') === -1) &&
-      (unescapedIndexOf(value, ':') === -1) &&
-      (unescapedIndexOf(value, ';') === -1)) {
+      (value.indexOf(',') === -1) &&
+      (value.indexOf(':') === -1) &&
+      (value.indexOf(';') === -1)) {
 
     return value;
   }

--- a/test/stringify_test.js
+++ b/test/stringify_test.js
@@ -113,6 +113,13 @@ suite('ICAL.stringify', function() {
       delete ICAL.design.defaultSet.param.type;
     });
 
+    test('stringify property value containing "escaped" semicolons, commas, colons', function() {
+      let subject = new ICAL.Property('attendee');
+      subject.setParameter('cn', 'X\\:');
+      subject.setValue('mailto:id');
+      assert.equal(subject.toICALString(), 'ATTENDEE;CN="X\\:":mailto:id');
+    });
+
     test('rfc6868 roundtrip', function() {
       let subject = new ICAL.Property('attendee');
       let input = "caret ^ dquote \" newline \n end";


### PR DESCRIPTION
… as `\` is no escape character there.  When the propery parameter contains `:`, then it must be quoted, the colon cannot be escaped.

As the function stringify.propertyValue in fact stringifies property parameter values, it is renamed accordingly.

This supersedes https://github.com/kewisch/ical.js/pull/535 and updates https://github.com/kewisch/ical.js/pull/555.

Without these changes, the herein added test fails:
```
1) ICAL.stringify
     stringify property
       stringify property value containing "escaped" ; , ::

    AssertionError: expected 'ATTENDEE;CN=X\::mailto:id' to equal 'ATTENDEE;CN="X\:":mailto:id'
    + expected - actual

    -ATTENDEE;CN=X\::mailto:id
    +ATTENDEE;CN="X\:":mailto:id
```