### PR TITLE
Make ical.es5.cjs an UMD module for browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,47 @@ and example links.
 There is also a validator that demonstrates how to use the library in a webpage in the
 [tools/](https://github.com/kewisch/ical.js/tree/main/tools) subdirectory.
 
-[Try the validator online](http://kewisch.github.io/ical.js/validator.html), it always uses the latest release of ICAL.js.
+[Try the validator online](http://kewisch.github.io/ical.js/validator.html), it always uses the
+latest release of ICAL.js.
 
 ## Installing
 
-You can install ICAL.js via [npm](https://www.npmjs.com/), if you would like to use it in Node.js:
-```
+ICAL.js has no dependencies and is written in modern JavaScript. You can install ICAL.js via
+[npm](https://www.npmjs.com/), if you would like to use it in Node.js:
+```bash
 npm install ical.js
 ```
+Then simply import it for use:
+```javascript
+import ICAL from "ical.js";
+```
 
-ICAL.js has no dependencies and is written in modern JavaScript. A version transpiled to ES5 is
-available as well. It should work in all versions of Node.js and modern browsers.
+If you are working with a browser, be aware this is an ES6 module:
+
+```html
+<script type="module">
+  import ICAL from "https://unpkg.com/ical.js";
+  document.querySelector("button").addEventListener("click", () => {
+    ICAL.parse(document.getElementById("txt").value);
+  });
+</script>
+```
+
+If you need to make use of a script tag, you can use the transpiled ES5 version:
+```html
+<script src="https://unpkg.com/ical.js/dist/ical.es5.cjs"></script>
+<textarea id="txt"></textarea>
+<button onclick="ICAL.parse(document.getElementById('txt').value)"></button>
+```
 
 ## Timezones
 The stock ical.js does not register any timezones, due to the additional size it brings. If you'd
 like to do timezone conversion, and the timezone definitions are not included in the respective ics
 files, you'll need to use `ical.timezones.js` or its minified counterpart.
+
+This file is not included in the distribution since it pulls in IANA timezones that might change
+regularly. See the github actions on building your own timezones during CI, or grab a recent build
+from main.
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ical.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ical.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Philipp Kewisch",
   "contributors": [
     "Github Contributors (https://github.com/kewisch/ical.js/graphs/contributors)"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,32 +1,55 @@
-import { getBabelOutputPlugin } from '@rollup/plugin-babel';
+import { babel } from '@rollup/plugin-babel';
 import { terser } from 'rollup-plugin-terser';
 
-export default {
+const LICENSE =
+`/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Portions Copyright (C) Philipp Kewisch */`;
+
+const TERSER_OPTIONS = {
+  format: {
+    comments: function(node, comment) {
+      if (comment.type == 'comment2') {
+        return /terms of the Mozilla Public/.test(comment.value) && comment.pos === 0;
+      }
+      return false;
+    }
+  }
+};
+
+export default [{
   input: 'lib/ical/module.js',
   output: [
-    { file: 'dist/ical.js', format: 'es', exports: "default" },
+    { file: 'dist/ical.js', format: 'es', exports: 'default' },
     {
       file: 'dist/ical.min.js',
+      banner: LICENSE,
       format: 'es',
-      exports: "default",
-      plugins: [terser()]
-    },
+      exports: 'default',
+      plugins: [terser(TERSER_OPTIONS)]
+    }
+  ]
+}, {
+  input: 'lib/ical/module.js',
+  output: [
     {
       file: 'dist/ical.es5.cjs',
-      exports: "default",
-      format: 'cjs',
-      plugins: [
-        getBabelOutputPlugin({ presets: ['@babel/preset-env'] })
-      ],
+      exports: 'default',
+      name: 'ICAL',
+      format: 'umd',
+      banner: LICENSE,
     },
     {
       file: 'dist/ical.es5.min.cjs',
-      exports: "default",
-      format: 'cjs',
-      plugins: [
-        getBabelOutputPlugin({ presets: ['@babel/preset-env'] }),
-        terser()
-      ]
+      exports: 'default',
+      name: 'ICAL',
+      format: 'umd',
+      banner: LICENSE,
+      plugins: [terser(TERSER_OPTIONS)],
     }
+  ],
+  plugins: [
+    babel({ babelHelpers: 'bundled', presets: ['@babel/preset-env'] })
   ]
-};
+}];


### PR DESCRIPTION
In version 2.0.0 ical.es5.cjs and ical.es5.min.cjs was a cjs module, which made it work with older version of node and use of `require()`. The regular version uses ES6 modules, so it needs to be imported instead of using a script tag. Therefore, none of the versions could be included in a <script> tag in the browser. You can now use the es5 version if you require <script> tag inclusion and would like an `ICAL` global on the window, and also if you require a cjs module in your node project.

[fixes #653]