### PR TITLE
Fix stack trace on custom ParserError

### DIFF
--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -93,22 +93,8 @@ parse.component = function(str) {
  * @extends {Error}
  * @class
  */
-
 class ParserError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = this.constructor.name;
-
-    try {
-      throw new Error();
-    } catch (e) {
-      if (e.stack) {
-        let split = e.stack.split('\n');
-        split.shift();
-        this.stack = split.join('\n');
-      }
-    }
-  }
+  name = this.constructor.name;
 }
 
 // classes & constants


### PR DESCRIPTION
I caught a ParserError with a weird stack, and it turns out the custom mangling we did before doesn't really cut it. With ES6+ we can simplify the instance variables.

I've only tested this in recent node and the firefox error console, both seem to contain a stack. The node stack even skips over the error class even without Error.captureStackTrace.

Does this look ok?