### PR TITLE
Handle parameter values with multiple entries

### DIFF
--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -165,7 +165,16 @@ parse._handleContentLine = function(line, state) {
       throw new ParserError("Invalid parameters in '" + line + "'");
     }
     params = parsedParams[0];
-    lastParamIndex = parsedParams[1].length + parsedParams[2] + paramPos;
+    // Handle parameter values with multiple entries
+    let parsedParamLength;
+    if (typeof parsedParams[1] === 'string') {
+      parsedParamLength = parsedParams[1].length;
+    } else {
+      parsedParamLength = parsedParams[1].reduce((accumulator, currentValue) => {
+        return accumulator + currentValue.length;
+      }, 0);
+    }
+    lastParamIndex = parsedParamLength + parsedParams[2] + paramPos;
     if ((lastValuePos =
       line.slice(Math.max(0, lastParamIndex)).indexOf(VALUE_DELIMITER)) !== -1) {
       value = line.slice(Math.max(0, lastParamIndex + lastValuePos + 1));
@@ -310,10 +319,11 @@ parse._parseValue = function(value, type, designSet, structuredValue) {
  *
  * @function ICAL.parse._parseParameters
  * @private
- * @param {String} line           A single unfolded line
- * @param {Number} start         Position to start looking for properties
- * @param {Object} designSet      The design data to use for this property
- * @return {Object} key/value pairs
+ * @param {String} line               A single unfolded line
+ * @param {Number} start              Position to start looking for properties
+ * @param {Object} designSet          The design data to use for this property
+ * @return {Array}                    Array containing key/valye pairs of parsed parameters, the
+ *                                      parsed value, and the position of the last parameter found
  */
 parse._parseParameters = function(line, start, designSet) {
   let lastParam = start;

--- a/test/failure_test.js
+++ b/test/failure_test.js
@@ -37,31 +37,4 @@ suite('Known failures', function() {
     assert.equal(subject.getParameter("cn"), "Z\\;");
     assert.equal(subject.getFirstValue(), "mailto:z@example.org");
   });
-
-  // Quoted multi-value parameters leak into the value
-  // Please see https://github.com/kewisch/ical.js/issues/634
-  testKnownFailure('with quoted multi-value parameter', function() {
-    let attendee = ICAL.Property.fromString(
-      'ATTENDEE;MEMBER=' +
-      '"mailto:mygroup@localhost",' +
-      '"mailto:mygroup2@localhost",' +
-      '"mailto:mygroup3@localhost":' +
-      'mailto:user2@localhost'
-    );
-
-    let expected = [
-      'attendee',
-      {
-        member: [
-          'mailto:mygroup@localhost',
-          'mailto:mygroup2@localhost',
-          'mailto:mygroup3@localhost'
-        ]
-      },
-      'cal-address',
-      'mailto:user2@localhost'
-    ];
-
-    assert.deepEqual(attendee.toJSON(), expected);
-  });
 });

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -227,6 +227,30 @@ suite('parserv2', function() {
       );
     });
 
+    test('with quoted multi-value parameter', function() {
+      let attendee = ICAL.Property.fromString(
+        'ATTENDEE;MEMBER=' +
+        '"mailto:mygroup@localhost",' +
+        '"mailto:mygroup2@localhost",' +
+        '"mailto:mygroup3@localhost":' +
+        'mailto:user2@localhost'
+      );
+      let expected = [
+        'attendee',
+        {
+          member: [
+            'mailto:mygroup@localhost',
+            'mailto:mygroup2@localhost',
+            'mailto:mygroup3@localhost'
+          ]
+        },
+        'cal-address',
+        'mailto:user2@localhost'
+      ];
+
+      assert.deepEqual(attendee.toJSON(), expected);
+    });
+
     test('with quoted value', function() {
       let input = ';FMTTYPE="text/html":Here is HTML with signs like =;';
       let expected = {


### PR DESCRIPTION
Fixing parser for quoted multi-value parameters. The PR fixes the string length detection of this parameter in case if it's not a simple single string but an array.

```
attendee = ICAL.Property.fromString(
  'ATTENDEE;MEMBER="mailto:mygroup@localhost","mailto:mygroup2@localhost":mailto:user2@localhost'
);
console.log(attendee);
```

Will now correctly return the attendee URI `mailto:user2@localhost`

Fixes https://github.com/kewisch/ical.js/issues/634