### PR TITLE
Fix remaining typescript issues

### DIFF
--- a/lib/ical/component.js
+++ b/lib/ical/component.js
@@ -95,7 +95,6 @@ class Component {
    * The name of this component
    *
    * @type {String}
-   * @readonly
    */
   get name() {
     return this.jCal[NAME_INDEX];

--- a/lib/ical/component.js
+++ b/lib/ical/component.js
@@ -9,6 +9,15 @@ import ICALParse from "./parse.js";
 import stringify from "./stringify.js";
 import design from "./design.js";
 
+/**
+ * This lets typescript resolve our custom types in the
+ * generated d.ts files (jsdoc typedefs are converted to typescript types).
+ * Ignore prevents the typedefs from being documented more than once.
+ * @ignore
+ * @typedef {import("./types.d.js").designSet} designSet
+ * Imports the 'designSet' type from the "types.d.js" module
+ */
+
 const NAME_INDEX = 0;
 const PROPERTY_INDEX = 1;
 const COMPONENT_INDEX = 2;
@@ -103,7 +112,7 @@ class Component {
   /**
    * The design set for this component, e.g. icalendar vs vcard
    *
-   * @type {ICAL.design.designSet}
+   * @type {designSet}
    * @private
    */
   get _designSet() {

--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -12,6 +12,15 @@ import Duration from "./duration.js";
 import Time from "./time.js";
 import Binary from "./binary.js";
 
+/**
+ * This lets typescript resolve our custom types in the
+ * generated d.ts files (jsdoc typedefs are converted to typescript types).
+ * Ignore prevents the typedefs from being documented more than once.
+ * @ignore
+ * @typedef {import("./types.d.js").designSet} designSet
+ * Imports the 'designSet' type from the "types.d.js" module
+ */
+
 /** @module ICAL.design */
 
 const FROM_ICAL_NEWLINE = /\\\\|\\;|\\,|\\[Nn]/g;
@@ -895,7 +904,7 @@ let vcard3Properties = extend(commonProperties, {
 
 /**
  * iCalendar design set
- * @type {ICAL.design.designSet}
+ * @type {designSet}
  */
 let icalSet = {
   value: icalValues,
@@ -906,7 +915,7 @@ let icalSet = {
 
 /**
  * vCard 4.0 design set
- * @type {ICAL.design.designSet}
+ * @type {designSet}
  */
 let vcardSet = {
   value: vcardValues,
@@ -917,7 +926,7 @@ let vcardSet = {
 
 /**
  * vCard 3.0 design set
- * @type {ICAL.design.designSet}
+ * @type {designSet}
  */
 let vcard3Set = {
   value: vcard3Values,
@@ -935,26 +944,13 @@ let vcard3Set = {
  */
 const design = {
   /**
-   * A designSet describes value, parameter and property data. It is used by
-   * ther parser and stringifier in components and properties to determine they
-   * should be represented.
-   *
-   * @typedef {Object} designSet
-   * @memberOf ICAL.design
-   * @property {Object} value       Definitions for value types, keys are type names
-   * @property {Object} param       Definitions for params, keys are param names
-   * @property {Object} property    Definitions for properties, keys are property names
-   * @property {boolean} propertyGroups  If content lines may include a group name
-   */
-
-  /**
    * Can be set to false to make the parser more lenient.
    */
   strict: true,
 
   /**
    * The default set for new properties and components if none is specified.
-   * @type {ICAL.design.designSet}
+   * @type {designSet}
    */
   defaultSet: icalSet,
 
@@ -968,14 +964,14 @@ const design = {
    * Holds the design set for known top-level components
    *
    * @type {Object}
-   * @property {ICAL.design.designSet} vcard       vCard VCARD
-   * @property {ICAL.design.designSet} vevent      iCalendar VEVENT
-   * @property {ICAL.design.designSet} vtodo       iCalendar VTODO
-   * @property {ICAL.design.designSet} vjournal    iCalendar VJOURNAL
-   * @property {ICAL.design.designSet} valarm      iCalendar VALARM
-   * @property {ICAL.design.designSet} vtimezone   iCalendar VTIMEZONE
-   * @property {ICAL.design.designSet} daylight    iCalendar DAYLIGHT
-   * @property {ICAL.design.designSet} standard    iCalendar STANDARD
+   * @property {designSet} vcard       vCard VCARD
+   * @property {designSet} vevent      iCalendar VEVENT
+   * @property {designSet} vtodo       iCalendar VTODO
+   * @property {designSet} vjournal    iCalendar VJOURNAL
+   * @property {designSet} valarm      iCalendar VALARM
+   * @property {designSet} vtimezone   iCalendar VTIMEZONE
+   * @property {designSet} daylight    iCalendar DAYLIGHT
+   * @property {designSet} standard    iCalendar STANDARD
    *
    * @example
    * let propertyName = 'fn';
@@ -1000,19 +996,19 @@ const design = {
 
   /**
    * The design set for iCalendar (rfc5545/rfc7265) components.
-   * @type {ICAL.design.designSet}
+   * @type {designSet}
    */
   icalendar: icalSet,
 
   /**
    * The design set for vCard (rfc6350/rfc7095) components.
-   * @type {ICAL.design.designSet}
+   * @type {designSet}
    */
   vcard: vcardSet,
 
   /**
    * The design set for vCard (rfc2425/rfc2426/rfc7095) components.
-   * @type {ICAL.design.designSet}
+   * @type {designSet}
    */
   vcard3: vcard3Set,
 
@@ -1020,7 +1016,7 @@ const design = {
    * Gets the design set for the given component name.
    *
    * @param {String} componentName        The name of the component
-   * @return {ICAL.design.designSet}      The design set for the component
+   * @return {designSet}      The design set for the component
    */
   getDesignSet: function(componentName) {
     let isInDesign = componentName && componentName in design.components;

--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -426,7 +426,6 @@ class Event {
   /**
    * The attendees in the event
    * @type {Property[]}
-   * @readonly
    */
   get attendees() {
     //XXX: This is way lame we should have a better

--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -38,10 +38,10 @@ class Event {
    * Creates a new ICAL.Event instance.
    *
    * @param {Component=} component              The ICAL.Component to base this event on
-   * @param {Object} options                    Options for this event
-   * @param {Boolean} options.strictExceptions  When true, will verify exceptions are related by
+   * @param {Object} [options]                  Options for this event
+   * @param {Boolean=} options.strictExceptions  When true, will verify exceptions are related by
    *                                              their UUID
-   * @param {Array<Component|Event>} options.exceptions
+   * @param {Array<Component|Event>=} options.exceptions
    *          Exceptions to this event, either as components or events. If not
    *            specified exceptions will automatically be set in relation of
    *            component's parent

--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -14,6 +14,8 @@ import { unescapedIndexOf } from "./helpers.js";
  * @ignore
  * @typedef {import("./types.d.js").parserState} parserState
  * Imports the 'parserState' type from the "types.d.js" module
+ * @typedef {import("./types.d.js").designSet} designSet
+ * Imports the 'designSet' type from the "types.d.js" module
  */
 
 const CHAR = /[^ \t]/;
@@ -67,7 +69,7 @@ export default function parse(input) {
  * @function ICAL.parse.property
  * @param {String} str
  *   The iCalendar property string to parse
- * @param {ICAL.design.designSet=} designSet
+ * @param {designSet=} designSet
  *   The design data to use for this property
  * @return {Object}
  *   The jCal Object containing the property
@@ -450,12 +452,12 @@ parse._rfc6868Escape = function(val) {
  *
  * @private
  * @function ICAL.parse._parseMultiValue
- * @param {String} buffer     The buffer containing the full value
- * @param {String} delim      The multi-value delimiter
- * @param {String} type       The value type to be parsed
+ * @param {String} buffer           The buffer containing the full value
+ * @param {String} delim            The multi-value delimiter
+ * @param {String} type             The value type to be parsed
  * @param {Array.<?>} result        The array to append results to, varies on value type
- * @param {String} innerMulti The inner delimiter to split each value with
- * @param {ICAL.design.designSet} designSet   The design data for this value
+ * @param {String} innerMulti       The inner delimiter to split each value with
+ * @param {designSet} designSet     The design data for this value
  * @return {?|Array.<?>}            Either an array of results, or the first result
  */
 parse._parseMultiValue = function(buffer, delim, type, result, innerMulti, designSet, structuredValue) {

--- a/lib/ical/parse.js
+++ b/lib/ical/parse.js
@@ -309,7 +309,7 @@ parse._parseValue = function(value, type, designSet, structuredValue) {
  * @function ICAL.parse._parseParameters
  * @private
  * @param {String} line           A single unfolded line
- * @param {Numeric} start         Position to start looking for properties
+ * @param {Number} start         Position to start looking for properties
  * @param {Object} designSet      The design data to use for this property
  * @return {Object} key/value pairs
  */

--- a/lib/ical/period.js
+++ b/lib/ical/period.js
@@ -10,6 +10,15 @@ import Duration from "./duration.js";
 import Property from "./property.js";
 
 /**
+ * This lets typescript resolve our custom types in the
+ * generated d.ts files (jsdoc typedefs are converted to typescript types).
+ * Ignore prevents the typedefs from being documented more than once.
+ * @ignore
+ * @typedef {import("./types.d.js").jCalComponent} jCalComponent
+ * Imports the 'occurrenceDetails' type from the "types.d.js" module
+ */
+
+/**
  * This class represents the "period" value type, with various calculation and manipulation methods.
  *
  * @memberof ICAL
@@ -65,7 +74,7 @@ class Period {
    * member is always the start date string, the second member is either a
    * duration or end date string.
    *
-   * @param {Array<String,String>} aData    The jCal data array
+   * @param {jCalComponent} aData           The jCal data array
    * @param {Property} aProp                The property this jCal data is on
    * @param {Boolean} aLenient              If true, data value can be both date and date-time
    * @return {Period}                       The period instance

--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -59,7 +59,6 @@ class Property {
 
   /**
    * The value type for this property
-   * @readonly
    * @type {String}
    */
   get type() {
@@ -68,7 +67,6 @@ class Property {
 
   /**
    * The name of this property, in lowercase.
-   * @readonly
    * @type {String}
    */
   get name() {

--- a/lib/ical/property.js
+++ b/lib/ical/property.js
@@ -16,6 +16,15 @@ import ICALStringify from "./stringify.js";
 import ICALParse from "./parse.js";
 
 /**
+ * This lets typescript resolve our custom types in the
+ * generated d.ts files (jsdoc typedefs are converted to typescript types).
+ * Ignore prevents the typedefs from being documented more than once.
+ * @ignore
+ * @typedef {import("./types.d.js").designSet} designSet
+ * Imports the 'designSet' type from the "types.d.js" module
+ */
+
+/**
  * Provides a layer on top of the raw jCal object for manipulating a single property, with its
  * parameters and value.
  *
@@ -25,9 +34,9 @@ class Property {
   /**
    * Create an {@link ICAL.Property} by parsing the passed iCalendar string.
    *
-   * @param {String} str                        The iCalendar string to parse
-   * @param {ICAL.design.designSet=} designSet  The design data to use for this property
-   * @return {Property}                         The created iCalendar property
+   * @param {String} str            The iCalendar string to parse
+   * @param {designSet=} designSet  The design data to use for this property
+   * @return {Property}             The created iCalendar property
    */
   static fromString(str, designSet) {
     return new Property(ICALParse.property(str, designSet));
@@ -97,7 +106,7 @@ class Property {
   /**
    * The design set for this property, e.g. icalendar vs vcard
    *
-   * @type {ICAL.design.designSet}
+   * @type {designSet}
    * @private
    */
   get _designSet() {

--- a/lib/ical/stringify.js
+++ b/lib/ical/stringify.js
@@ -6,6 +6,16 @@
 import design from "./design.js";
 import { foldline } from "./helpers.js";
 
+/**
+ * This lets typescript resolve our custom types in the
+ * generated d.ts files (jsdoc typedefs are converted to typescript types).
+ * Ignore prevents the typedefs from being documented more than once.
+ *
+ * @ignore
+ * @typedef {import("./types.d.js").designSet} designSet
+ * Imports the 'designSet' type from the "types.d.js" module
+ */
+
 const LINE_ENDING = '\r\n';
 const DEFAULT_VALUE_TYPE = 'unknown';
 const RFC6868_REPLACE_MAP = { '"': "^'", "\n": "^n", "^": "^^" };
@@ -45,7 +55,7 @@ export default function stringify(jCal) {
  * @function ICAL.stringify.component
  * @param {Array} component
  *        jCal/jCard fragment of a component
- * @param {ICAL.design.designSet} designSet
+ * @param {designSet} designSet
  *        The design data to use for this component
  * @return {String}       The iCalendar/vCard string
  */
@@ -89,7 +99,7 @@ stringify.component = function(component, designSet) {
  * @function ICAL.stringify.property
  * @param {Array} property
  *        jCal/jCard property array
- * @param {ICAL.design.designSet} designSet
+ * @param {designSet} designSet
  *        The design data to use for this property
  * @param {Boolean} noFold
  *        If true, the line is not folded
@@ -236,7 +246,7 @@ stringify.paramPropertyValue = function(value, force) {
  *        (like boolean, date-time, etc..)
  * @param {?String} innerMulti If set, each value will again be processed
  *        Used for structured values
- * @param {ICAL.design.designSet} designSet
+ * @param {designSet} designSet
  *        The design data to use for this property
  *
  * @return {String}           iCalendar/vCard string for value

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -422,7 +422,6 @@ class Time {
   /**
    * The type name, to be used in the jCal object. This value may change and
    * is strictly defined by the {@link ICAL.Time#isDate isDate} member.
-   * @readonly
    * @type {String}
    * @default "date-time"
    */

--- a/lib/ical/timezone_service.js
+++ b/lib/ical/timezone_service.js
@@ -4,6 +4,8 @@
  * Portions Copyright (C) Philipp Kewisch */
 
 import Timezone from "./timezone.js";
+// needed for typescript type resolution
+// eslint-disable-next-line no-unused-vars
 import Component from "./component.js";
 
 let zones = null;

--- a/lib/ical/timezone_service.js
+++ b/lib/ical/timezone_service.js
@@ -99,7 +99,7 @@ const TimezoneService = {
     }
 
     if (!timezone.tzid && !name) {
-      throw new TypeError("neither a timezone nor a name was passed");
+      throw new TypeError("Neither a timezone nor a name was passed");
     }
 
     if (timezone instanceof Timezone) {

--- a/lib/ical/timezone_service.js
+++ b/lib/ical/timezone_service.js
@@ -98,7 +98,7 @@ const TimezoneService = {
       }
     }
 
-    if (!timezone.tzid && !name) {
+    if (!name) {
       throw new TypeError("Neither a timezone nor a name was passed");
     }
 

--- a/lib/ical/timezone_service.js
+++ b/lib/ical/timezone_service.js
@@ -69,22 +69,37 @@ const TimezoneService = {
   /**
    * Registers a timezone object or component.
    *
+   * @param {Component|Timezone} timezone
+   *        The initialized zone or vtimezone.
+   *
    * @param {String=} name
    *        The name of the timezone. Defaults to the component's TZID if not
    *        passed.
-   * @param {Component|Timezone} timezone
-   *        The initialized zone or vtimezone.
    */
-  register: function(name, timezone) {
+  register: function(timezone, name) {
     if (zones === null) {
       this.reset();
     }
 
-    if (name instanceof Component) {
-      if (name.name === 'vtimezone') {
-        timezone = new Timezone(name);
+    // This avoids a breaking change by the change of argument order
+    // TODO remove in v3
+    if (typeof timezone === "string" && name instanceof Timezone) {
+      [timezone, name] = [name, timezone];
+    }
+
+    if (!name) {
+      if (timezone instanceof Timezone) {
         name = timezone.tzid;
+      } else {
+        if (timezone.name === 'vtimezone') {
+          timezone = new Timezone(timezone);
+          name = timezone.tzid;
+        }
       }
+    }
+
+    if (!timezone.tzid && !name) {
+      throw new TypeError("neither a timezone nor a name was passed");
     }
 
     if (timezone instanceof Timezone) {

--- a/lib/ical/types.d.js
+++ b/lib/ical/types.d.js
@@ -46,4 +46,19 @@ import Component from "./component";
  * @property {Component} component           The currently active component
  */
 
+/**
+ * A jCal component.
+ *
+ * TODO: Properly typedef this when https://github.com/hegemonic/catharsis/pull/70
+ * is merged. Documentation is ignored until this can be documented properly.
+ *
+ * @example
+ *     ["vevent", [...properties here...], [...components here...] ]
+ *
+ * @ignore
+ * @typedef {Array} jCalComponent
+ * @property {String} 0               The component name
+ * @property {jCalProperty[]} 1       The properties of this component
+ * @property {jCalComponent[]} 2      The subcomponents of this component
+ */
 export const _ = {};

--- a/lib/ical/types.d.js
+++ b/lib/ical/types.d.js
@@ -41,7 +41,7 @@ import Component from "./component";
  * @private
  * @memberof ICAL.parse
  * @typedef {Object} parserState
- * @property {ICAL.design.designSet} designSet    The design set to use for parsing
+ * @property {designSet} designSet           The design set to use for parsing
  * @property {Component[]} stack             The stack of components being processed
  * @property {Component} component           The currently active component
  */
@@ -61,4 +61,18 @@ import Component from "./component";
  * @property {jCalProperty[]} 1       The properties of this component
  * @property {jCalComponent[]} 2      The subcomponents of this component
  */
+
+/**
+ * A designSet describes value, parameter and property data. It is used by
+ * ther parser and stringifier in components and properties to determine they
+ * should be represented.
+ *
+ * @memberof ICAL.design
+ * @typedef {Object} designSet
+ * @property {Object} value       Definitions for value types, keys are type names
+ * @property {Object} param       Definitions for params, keys are param names
+ * @property {Object} property    Definitions for properties, keys are property names
+ * @property {boolean} propertyGroups  If content lines may include a group name
+ */
+
 export const _ = {};

--- a/test/timezone_service_test.js
+++ b/test/timezone_service_test.js
@@ -79,7 +79,7 @@ suite('timezone_service', function() {
       assert.throws(function() {
         let comp = new ICAL.Component('vtoaster');
         subject.register(comp);
-      }, "timezone must be ICAL.Timezone");
+      }, "neither a timezone nor a name was passed");
     });
 
     test('override', function() {

--- a/test/timezone_service_test.js
+++ b/test/timezone_service_test.js
@@ -79,7 +79,7 @@ suite('timezone_service', function() {
       assert.throws(function() {
         let comp = new ICAL.Component('vtoaster');
         subject.register(comp);
-      }, "neither a timezone nor a name was passed");
+      }, "Neither a timezone nor a name was passed");
     });
 
     test('override', function() {


### PR DESCRIPTION
Hi,
according to #707 there are some remaining issues with the generated typescript types. This PR aims to fix everything except those regarding `ICAL.design.designSet` since that is currently broken. Some commits need an explanation:

- Remove `@readonly` tags because it causes this error in typescript: `readonly' modifier can only appear on a property declaration or index signature.`. When the getters get converted to typescript, typescript changes `@readonly` to the typescript keyword `readonly` which is only allowed in index signatures or properties. However you use the `@readonly` tag on getter functions which is not valid in typescript. I couldn't find a way to omit specific valid jsdoc comments from being parsed by typescript (`@ts-ignore` doesnt work and `@ignore` removed the function from the docs).
- Made the options object optional because otherwise it causes `A required parameter cannot follow an optional parameter.`. Also I took a look at the code and believe that `options` itself and their properties should be optional anyways since `options.strictExceptions` is set in the property declaration to false and  `options.exceptions` states that "If not specified exceptions will automatically be set in relation of compoent's parent"