### PR TITLE
Fix module resolution in typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   },
   "exports": {
     "import": "./dist/ical.js",
-    "require": "./dist/ical.es5.cjs"
+    "require": "./dist/ical.es5.cjs",
+    "types": "./dist/types/module.d.ts"
   },
   "files": [
     "dist/ical.js",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dist/ical.min.js",
     "dist/ical.es5.cjs",
     "dist/ical.es5.min.cjs",
-    "dist/types/*.d.ts",
+    "dist/types/*",
     "lib/ical/*.js"
   ],
   "mocha": {


### PR DESCRIPTION
Hi, I've found another small issue when using typescript with this package. When using the tsconfig options `module: "NodeNext"` and `moduleResolution: "NodeNext"`, tsc showed the following error:

```txt
test.ts:1:18 - error TS7016: Could not find a declaration file for module 'ical'. '/icalpath/node_modules/ical/dist/ical.js' implicitly has an 'any' type.
  There are types at '/icalpath/node_modules/ical/dist/types/module.d.ts', but this result could not be resolved when respecting package.json "exports". The 'ical.js' library may need to update its package.json or typings.

1 import ICAL from "ical";
                   ~~~~~~~
Found 1 error in test.ts:1
```
This was fixed by b3821e0.

Also I noticed that when using typescript and go to definition VSCode would go to the `.d.ts` files instead of the js sources. This was fixed by adding the declarationmaps to the package which allow VSCode or another language server to connect the declarations and the source js files. 9401238.
