### PR TITLE
iCalendar Duration RFC Compliance Fix

### DIFF
--- a/lib/ical/duration.js
+++ b/lib/ical/duration.js
@@ -273,15 +273,35 @@ class Duration {
       let str = "";
       if (this.isNegative) str += "-";
       str += "P";
-      if (this.weeks) str += this.weeks + "W";
-      if (this.days) str += this.days + "D";
-
-      if (this.hours || this.minutes || this.seconds) {
-        str += "T";
-        if (this.hours) str += this.hours + "H";
-        if (this.minutes) str += this.minutes + "M";
-        if (this.seconds) str += this.seconds + "S";
+      let hasWeeks = false;
+      if (this.weeks) {
+        if (this.days || this.hours || this.minutes || this.seconds) {
+          str += (this.weeks * 7 + this.days) + "D";
+        } else {
+          str += (this.weeks + "W");
+          hasWeeks = true;
+        }
+      } else if (this.days) {
+        str += (this.days + "D");
       }
+
+      if (!hasWeeks) {
+        if (this.hours || this.minutes || this.seconds) {
+          str += "T";
+          if (this.hours) {
+            str += this.hours + "H";
+          }
+
+          if (this.minutes) {
+            str += this.minutes + "M";
+          }
+
+          if (this.seconds) {
+            str += this.seconds + "S";
+          }
+        }
+      }
+
       return str;
     }
   }

--- a/test/rfc_duration_test.js
+++ b/test/rfc_duration_test.js
@@ -1,0 +1,37 @@
+ suite("ical/duration - fromSeconds → toString", function() {
+   test("pure weeks → P2W", function() {
+    let Duration = new ICAL.Duration();
+    let d = Duration.fromSeconds(2 * 7 * 86400);
+    assert.equal(d.toString(), "P2W");
+   });
+
+   test("pure days → P3D", function() {
+    let Duration = new ICAL.Duration();
+    let d = Duration.fromSeconds(3 * 86400);
+    assert.equal(d.toString(), "P3D");
+   });
+
+   test("pure time → PT5H30M5S", function() {
+    let Duration = new ICAL.Duration();
+    let d = Duration.fromSeconds(5 * 3600 + 30 * 60 + 5);
+    assert.equal(d.toString(), "PT5H30M5S");
+   });
+
+   test("1 day + 2 hours → P1DT2H", function() {
+    let Duration = new ICAL.Duration();
+    let d = Duration.fromSeconds(86400 + 2 * 3600);
+    assert.equal(d.toString(), "P1DT2H");
+   });
+
+   test("9 days → P9D", function() {
+    let Duration = new ICAL.Duration();
+    let d = Duration.fromSeconds(9 * 86400);
+    assert.equal(d.toString(), "P9D");
+   });
+
+   test("10 days + 2 hours → P10DT2H", function() {
+    let Duration = new ICAL.Duration();
+    let d = Duration.fromSeconds(10 * 86400 + 2 * 3600);
+    assert.equal(d.toString(), "P10DT2H");
+   });
+ });


### PR DESCRIPTION
Previously, duration was not compliant with RFC Guidelines, leading to synchronization errors. We have modified the toString function in duration.js to ensure RFC compliant duration, and prevent synchronization errors.

Issue Link: https://github.com/kewisch/ical.js/issues/732