### PR TITLE
Fix support for parsing UTC Dates with trailing decimal seconds

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -184,7 +184,7 @@ class Time {
     let zone;
     let zoneId;
 
-    if (aValue[19] && aValue[19] === 'Z' || aValue.slice(-1) === 'Z') {
+    if (aValue.slice(-1) === 'Z') {
       zone = Timezone.utcTimezone;
     } else if (prop) {
       zoneId = prop.getParameter('tzid');

--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -184,7 +184,7 @@ class Time {
     let zone;
     let zoneId;
 
-    if (aValue[19] && aValue[19] === 'Z') {
+    if (aValue[19] && aValue[19] === 'Z' || aValue.slice(-1) === 'Z') {
       zone = Timezone.utcTimezone;
     } else if (prop) {
       zoneId = prop.getParameter('tzid');

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -255,6 +255,33 @@ suite('icaltime', function() {
     });
   });
 
+  suite('#fromDateTimeString', function() {
+    test('utc without decimals', function() {
+      let date = "2012-01-01T00:00:00Z";
+      let expected = date;
+      let subject = Time.fromDateTimeString(date);
+      assert.equal(
+        subject.toString(),
+        expected);
+    });
+    test('utc with decimals', function() {
+      let date = "2012-01-01T00:00:00.000Z";
+      let expected = new Date(date);
+      let subject = Time.fromDateTimeString(date);
+      assert.deepEqual(
+        subject.toJSDate(),
+        expected);
+    });
+    test('local time with decimals', function() {
+      let date = "2012-01-01T00:00:00.000";
+      let expected = new Date(date);
+      let subject = Time.fromDateTimeString(date);
+      assert.deepEqual(
+        subject.toJSDate(),
+        expected);
+    });
+  });
+
   suite('#fromJSDate', function() {
 
     test('utc', function() {


### PR DESCRIPTION
This allows date-time strings to be specified in the native way that native JS `Date.toISOString()` and `Date.toJSON()` are formatted (in the form `2025-05-15T03:09:02.000Z`, for example). They were already correctly imported, except that the trailing Z to specify UTC wasn't detected, since it was hardcoded to check only the 19th character, so they were interpreted as floating time.

This fix also means the format used in the newer Temporal API's `instant.toJSON()` and `instant.toString()` are supported as well.

In case there's any other software that appends something else to the string and depends on the Z being at the 19th character, it still handles that case as well, though that can of course be easily adjusted if that behavior is not desired. 