### PR TITLE
Improve typing of the Time class

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -21,6 +21,10 @@ import { strictParseInt, trunc, pad2 } from "./helpers.js";
  * @ignore
  * @typedef {import("./types.js").weekDay} weekDay
  * Imports the 'weekDay' type from the "types.js" module
+ *
+ * @ignore
+ * @typedef {import("./types.js").timeInit} timeInit
+ * Imports the 'timeInit' type from the "types.js" module
  */
 
 /**
@@ -248,15 +252,7 @@ class Time {
   /**
    * Creates a new ICAL.Time instance from the the passed data object.
    *
-   * @param {Object} aData            Time initialization
-   * @param {Number=} aData.year      The year for this date
-   * @param {Number=} aData.month     The month for this date
-   * @param {Number=} aData.day       The day for this date
-   * @param {Number=} aData.hour      The hour for this date
-   * @param {Number=} aData.minute    The minute for this date
-   * @param {Number=} aData.second    The second for this date
-   * @param {Boolean=} aData.isDate   If true, the instance represents a date
-   *                                    (as opposed to a date-time)
+   * @param {timeInit} aData          Time initialization
    * @param {Timezone=} aZone         Timezone this position occurs in
    */
   static fromData = function fromData(aData, aZone) {
@@ -384,29 +380,26 @@ class Time {
   /**
    * Creates a new ICAL.Time instance.
    *
-   * @param {Object} data           Time initialization
-   * @param {Number=} data.year     The year for this date
-   * @param {Number=} data.month    The month for this date
-   * @param {Number=} data.day      The day for this date
-   * @param {Number=} data.hour     The hour for this date
-   * @param {Number=} data.minute   The minute for this date
-   * @param {Number=} data.second   The second for this date
-   * @param {Boolean=} data.isDate  If true, the instance represents a date (as
-   *                                  opposed to a date-time)
-   * @param {Timezone} zone         timezone this position occurs in
+   * @param {timeInit} data           Time initialization
+   * @param {Timezone} zone           timezone this position occurs in
    */
   constructor(data, zone) {
     this.wrappedJSObject = this;
-    let time = this._time = Object.create(null);
+
+    /**
+     * @type {timeInit}
+     * @private
+     */
+    this._time = Object.create(null);
 
     /* time defaults */
-    time.year = 0;
-    time.month = 1;
-    time.day = 1;
-    time.hour = 0;
-    time.minute = 0;
-    time.second = 0;
-    time.isDate = false;
+    this._time.year = 0;
+    this._time.month = 1;
+    this._time.day = 1;
+    this._time.hour = 0;
+    this._time.minute = 0;
+    this._time.second = 0;
+    this._time.isDate = false;
 
     this.fromData(data, zone);
   }
@@ -445,6 +438,123 @@ class Time {
    * @private
    */
   _pendingNormalization = false;
+
+  /**
+   * The year of this date.
+   * @type {Number}
+   */
+  get year() {
+    return this._getTimeAttr('year');
+  }
+
+  set year(val) {
+    this._setTimeAttr('year', val);
+  }
+
+  /**
+   * The month of this date.
+   * @type {Number}
+   */
+  get month() {
+    return this._getTimeAttr('month');
+  }
+
+  set month(val) {
+    this._setTimeAttr('month', val);
+  }
+
+  /**
+   * The day of this date.
+   * @type {Number}
+   */
+  get day() {
+    return this._getTimeAttr('day');
+  }
+
+  set day(val) {
+    this._setTimeAttr('day', val);
+  }
+
+  /**
+   * The hour of this date-time.
+   * @type {Number}
+   */
+  get hour() {
+    return this._getTimeAttr('hour');
+  }
+
+  set hour(val) {
+    this._setTimeAttr('hour', val);
+  }
+
+  /**
+   * The minute of this date-time.
+   * @type {Number}
+   */
+  get minute() {
+    return this._getTimeAttr('minute');
+  }
+
+  set minute(val) {
+    this._setTimeAttr('minute', val);
+  }
+
+  /**
+   * The second of this date-time.
+   * @type {Number}
+   */
+  get second() {
+    return this._getTimeAttr('second');
+  }
+
+  set second(val) {
+    this._setTimeAttr('second', val);
+  }
+
+  /**
+   * If true, the instance represents a date (as opposed to a date-time)
+   * @type {Boolean}
+   */
+  get isDate() {
+    return this._getTimeAttr('isDate');
+  }
+
+  set isDate(val) {
+    this._setTimeAttr('isDate', val);
+  }
+
+  /**
+   * @private
+   * @param {String} attr             Attribute to get (one of: year, month,
+   *                                  day, hour, minute, second, isDate)
+   * @return {Number|Boolean}         Current value for the attribute
+   */
+  _getTimeAttr(attr) {
+    if (this._pendingNormalization) {
+      this._normalize();
+      this._pendingNormalization = false;
+    }
+
+    return this._time[attr];
+  }
+
+  /**
+   * @private
+   * @param {String} attr             Attribute to set (one of: year, month,
+   *                                  day, hour, minute, second, isDate)
+   * @param {Number|Boolean} val      New value for the attribute
+   */
+  _setTimeAttr(attr, val) {
+    // Check if isDate will be set and if was not set to normalize date.
+    // This avoids losing days when seconds, minutes and hours are zeroed
+    // what normalize will do when time is a date.
+    if (attr === "isDate" && val && !this._time.isDate) {
+      this.adjust(0, 0, 0, 0);
+    }
+    this._cachedUnixTime = null;
+    this._pendingNormalization = true;
+    this._time[attr] = val;
+  }
 
   /**
    * Returns a clone of the time object.
@@ -521,15 +631,7 @@ class Time {
   /**
    * Sets up the current instance using members from the passed data object.
    *
-   * @param {Object} aData            Time initialization
-   * @param {Number=} aData.year      The year for this date
-   * @param {Number=} aData.month     The month for this date
-   * @param {Number=} aData.day       The day for this date
-   * @param {Number=} aData.hour      The hour for this date
-   * @param {Number=} aData.minute    The minute for this date
-   * @param {Number=} aData.second    The second for this date
-   * @param {Boolean=} aData.isDate   If true, the instance represents a date
-   *                                    (as opposed to a date-time)
+   * @param {timeInit} aData          Time initialization
    * @param {Timezone=} aZone         Timezone this position occurs in
    */
   fromData(aData, aZone) {
@@ -1301,39 +1403,3 @@ class Time {
   }
 }
 export default Time;
-
-(function setupNormalizeAttributes() {
-  // This needs to run before any instances are created!
-  function defineAttr(attr) {
-    Object.defineProperty(Time.prototype, attr, {
-      get: function getTimeAttr() {
-        if (this._pendingNormalization) {
-          this._normalize();
-          this._pendingNormalization = false;
-        }
-
-        return this._time[attr];
-      },
-      set: function setTimeAttr(val) {
-        // Check if isDate will be set and if was not set to normalize date.
-        // This avoids losing days when seconds, minutes and hours are zeroed
-        // what normalize will do when time is a date.
-        if (attr === "isDate" && val && !this._time.isDate) {
-          this.adjust(0, 0, 0, 0);
-        }
-        this._cachedUnixTime = null;
-        this._pendingNormalization = true;
-        this._time[attr] = val;
-      }
-    });
-
-  }
-
-    defineAttr("year");
-    defineAttr("month");
-    defineAttr("day");
-    defineAttr("hour");
-    defineAttr("minute");
-    defineAttr("second");
-    defineAttr("isDate");
-})();

--- a/lib/ical/types.js
+++ b/lib/ical/types.js
@@ -12,12 +12,28 @@
 import Component from "./component";
 import Event from "./event";
 import Time from "./time";
+import Timezone from "./timezone";
 
 /**
  * The weekday, 1 = SUNDAY, 7 = SATURDAY. Access via
  * ICAL.Time.MONDAY, ICAL.Time.TUESDAY, ...
  *
  * @typedef {Number} weekDay
+ * @memberof ICAL.Time
+ */
+
+/**
+ * @typedef {Object} timeInit         Time initialization
+ * @property {Number=} year           The year for this date
+ * @property {Number=} month          The month for this date
+ * @property {Number=} day            The day for this date
+ * @property {Number=} hour           The hour for this date
+ * @property {Number=} minute         The minute for this date
+ * @property {Number=} second         The second for this date
+ * @property {Boolean=} isDate        If true, the instance represents a date
+ *                                    (as opposed to a date-time)
+ * @property {String=} timezone       Timezone id if zone is unknown [internal]
+ * @property {Timezone=} zone         Resolved timezone object [internal]
  * @memberof ICAL.Time
  */
 


### PR DESCRIPTION
Hi, I'm currently in the process of migrating a downstream library to TypeScript and noticed some missing types.

Let me know in case you have feedback and thanks for maintaining ical.js.

## Benefits
1. Improve support for downstream TypeScript consumers of this library.
2. Improve documentation by providing more accurate types.
3. Reduce side effects by not having to inject getters/setters at run time.

## Preview

The sections below show excerpts from `dist/types/time.d.ts`.

### Before

```ts
class Time {
    year: number;
    month: number;
    day: any;
    hour: any;
    minute: any;
    second: any;
    isDate: boolean;
}
```

### After

```ts
class Time {
    set year(val: number);
    /**
     * The year of this date.
     * @type {Number}
     */
    get year(): number;
    set month(val: number);
    /**
     * The month of this date.
     * @type {Number}
     */
    get month(): number;
    set day(val: number);
    /**
     * The day of this date.
     * @type {Number}
     */
    get day(): number;
    set hour(val: number);
    /**
     * The hour of this date-time.
     * @type {Number}
     */
    get hour(): number;
    set minute(val: number);
    /**
     * The minute of this date-time.
     * @type {Number}
     */
    get minute(): number;
    set second(val: number);
    /**
     * The second of this date-time.
     * @type {Number}
     */
    get second(): number;
    set isDate(val: boolean);
    /**
     * If true, the instance represents a date (as opposed to a date-time)
     * @type {Boolean}
     */
    get isDate(): boolean;
}
```