### PR TITLE
Fix invalid param type in Time.compareDateOnlyTz()

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -990,7 +990,7 @@ class Time {
   /**
    * Compares only the date part of this instance with another one.
    *
-   * @param {Duration} other              The instance to compare with
+   * @param {Time} other                  The instance to compare with
    * @param {Timezone} tz                 The timezone to compare in
    * @return {Number}                     -1, 0 or 1 for less/equal/greater
    */


### PR DESCRIPTION
Another small jsdoc fix.