### PR TITLE
Fix #509. Stop iterating months if no occurrences found in 28 years.

### DIFF
--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -367,7 +367,7 @@ class RecurIterator {
           // The longest possible sequence of skipped months is February-April-June,
           // so we might need to call next_month up to three times.
           if (!this.next_month() && !this.next_month() && !this.next_month()) {
-            throw new Error("No possible occurrences");
+            throw new InvalidRecurrenceRuleError();
           }
         }
       }
@@ -397,6 +397,7 @@ class RecurIterator {
     }
 
     let valid;
+    let invalid_count = 0;
     do {
       valid = 1;
 
@@ -418,6 +419,13 @@ class RecurIterator {
         break;
       case "MONTHLY":
         valid = this.next_month();
+        if (valid) {
+          invalid_count = 0;
+        } else if (++invalid_count == 336) {
+          // We've been through all the possible months and not found a recurrence. Stop.
+          this.completed = true;
+          return null;
+        }
         break;
       case "YEARLY":
         this.next_year();

--- a/test/recur_iterator_test.js
+++ b/test/recur_iterator_test.js
@@ -144,13 +144,6 @@ suite('recur_iterator', function() {
       let start = ICAL.Time.fromString(options.dtStart);
       let recur = ICAL.Recur.fromString(ruleString);
 
-      if (options.throws) {
-        assert.throws(function() {
-          recur.iterator(start);
-        });
-        return;
-      }
-
       let iterator = recur.iterator(start);
 
       if (options.noInstance) {
@@ -814,7 +807,7 @@ suite('recur_iterator', function() {
       // Invalid rule. There's never a 31st of Feburary, check that this fails.
       testRRULE('FREQ=MONTHLY;INTERVAL=12;BYMONTHDAY=31', {
         dtStart: '2022-02-01T08:00:00',
-        throws: true,
+        noInstance: true,
       });
 
       // monthly + by month
@@ -1431,6 +1424,18 @@ suite('recur_iterator', function() {
           '2016-02-07',
           '2016-03-06',
         ]
+      });
+
+      // Invalid recurrence rule. There can't be a second first Thursday.
+      testRRULE('FREQ=MONTHLY;BYDAY=1TH;BYSETPOS=2', {
+        dtStart: '2015-01-11T08:00:00',
+        noInstance: true
+      });
+
+      // Invalid recurrence rule. There can't be a 24th weekday in a month.
+      testRRULE('FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=24', {
+        dtStart: '2025-07-18T00:00:00',
+        noInstance: true
       });
 
       //YEARLY TESTS


### PR DESCRIPTION
In 28 years all possible combinations of month, day of week, and leap year have been tested. If we find no occurrence in that time we're never going to.

The filed bugs give a recurrence rule that is trivially wrong. I could optimise for this, but I've instead gone for a general case which should prevent all infinite loops in monthly recurring rules.