### PR TITLE
Prevent BYYEARDAY=366 from wrapping into the next year.

### DIFF
--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -294,7 +294,12 @@ class RecurIterator {
         throw new InvalidRecurrenceRuleError();
       }
 
-      this._nextByYearDay();
+      // If there's no occurrence in this year, try the following years. This
+      // would only happen looking for day 366 or -366.
+      if (!this._nextByYearDay() && !this.next_year() && !this.next_year() && !this.next_year()) {
+        // This should not be possible, but just in case it is, stop.
+        throw new InvalidRecurrenceRuleError();
+      }
     }
 
     if (this.rule.freq == "MONTHLY") {
@@ -422,13 +427,22 @@ class RecurIterator {
         if (valid) {
           invalid_count = 0;
         } else if (++invalid_count == 336) {
-          // We've been through all the possible months and not found a recurrence. Stop.
+          // We've been through all 91 month variations and not found a recurrence. Stop.
+          // (12 months and 29-day February × 7 starting days.)
           this.completed = true;
           return null;
         }
         break;
       case "YEARLY":
-        this.next_year();
+        valid = this.next_year();
+        if (valid) {
+          invalid_count = 0;
+        } else if (++invalid_count == 28) {
+          // We've been through all 14 year variations and not found a recurrence. Stop.
+          // (365-day and 366-day years × 7 starting days.)
+          this.completed = true;
+          return null;
+        }
         break;
 
       default:
@@ -887,29 +901,33 @@ class RecurIterator {
       return 0;
     }
 
-    if (++this.days_index == this.days.length) {
+    if (this.days.length == 0 || ++this.days_index == this.days.length) {
       this.days_index = 0;
-      do {
-        this.increment_year(this.rule.interval);
-        if (this.has_by_data("BYMONTHDAY")) {
-          this.by_data.BYMONTHDAY = this.normalizeByMonthDayRules(
-            this.last.year,
-            this.last.month,
-            this.rule.parts.BYMONTHDAY
-          );
-        }
-        this.expand_year_days(this.last.year);
-      } while (this.days.length == 0);
+      this.increment_year(this.rule.interval);
+      if (this.has_by_data("BYMONTHDAY")) {
+        this.by_data.BYMONTHDAY = this.normalizeByMonthDayRules(
+          this.last.year,
+          this.last.month,
+          this.rule.parts.BYMONTHDAY
+        );
+      }
+      this.expand_year_days(this.last.year);
+      if (this.days.length == 0) {
+        return 0;
+      }
     }
 
-    this._nextByYearDay();
-
-    return 1;
+    return this._nextByYearDay();
   }
 
   _nextByYearDay() {
     let doy = this.days[this.days_index];
     let year = this.last.year;
+
+    if (Math.abs(doy) == 366 && !Time.isLeapYear(this.last.year)) {
+      return 0;
+    }
+
     if (doy < 1) {
         // Time.fromDayOfYear(doy, year) indexes relative to the
         // start of the given year. That is different from the
@@ -921,6 +939,8 @@ class RecurIterator {
     let next = Time.fromDayOfYear(doy, year);
     this.last.day = next.day;
     this.last.month = next.month;
+
+    return 1;
   }
 
   /**

--- a/test/recur_iterator_test.js
+++ b/test/recur_iterator_test.js
@@ -1089,6 +1089,74 @@ suite('recur_iterator', function() {
         noInstance: true,
       });
 
+      // BYYEARDAY bounds.
+
+      // 1st day of the year.
+      testRRULE('FREQ=YEARLY;BYYEARDAY=1', {
+        dtStart: '2025-01-01T00:00:00',
+        dates: [
+          '2025-01-01T00:00:00',
+          '2026-01-01T00:00:00',
+          '2027-01-01T00:00:00',
+          '2028-01-01T00:00:00',
+          '2029-01-01T00:00:00',
+        ],
+      });
+
+      // 365th day of the year.
+      testRRULE('FREQ=YEARLY;BYYEARDAY=365', {
+        dtStart: '2025-01-01T00:00:00',
+        dates: [
+          '2025-12-31T00:00:00',
+          '2026-12-31T00:00:00',
+          '2027-12-31T00:00:00',
+          '2028-12-30T00:00:00',
+          '2029-12-31T00:00:00',
+        ],
+      });
+
+      // 366th day of the year. Only in leap years.
+      testRRULE('FREQ=YEARLY;BYYEARDAY=366', {
+        dtStart: '2025-01-01T00:00:00',
+        dates: [
+          '2028-12-31T00:00:00',
+          '2032-12-31T00:00:00',
+        ],
+      });
+
+      // Last day of the year.
+      testRRULE('FREQ=YEARLY;BYYEARDAY=-1', {
+        dtStart: '2025-01-01T00:00:00',
+        dates: [
+          '2025-12-31T00:00:00',
+          '2026-12-31T00:00:00',
+          '2027-12-31T00:00:00',
+          '2028-12-31T00:00:00',
+          '2029-12-31T00:00:00',
+        ],
+      });
+
+      // 365th-to-last day of the year.
+      testRRULE('FREQ=YEARLY;BYYEARDAY=-365', {
+        dtStart: '2025-01-01T00:00:00',
+        dates: [
+          '2025-01-01T00:00:00',
+          '2026-01-01T00:00:00',
+          '2027-01-01T00:00:00',
+          '2028-01-02T00:00:00',
+          '2029-01-01T00:00:00',
+        ],
+      });
+
+      // 366th-to-last day of the year. Only in leap years.
+      testRRULE('FREQ=YEARLY;BYYEARDAY=-366', {
+        dtStart: '2025-01-01T00:00:00',
+        dates: [
+          '2028-01-01T00:00:00',
+          '2032-01-01T00:00:00',
+        ],
+      });
+
       // Tycho brahe days - yearly, byYearDay with negative offsets
       testRRULE('FREQ=YEARLY;BYYEARDAY=1,2,4,6,11,12,20,42,48,49,-306,-303,' +
                 '-293,-292,-266,-259,-258,-239,-228,-209,-168,-164,-134,-133,' +


### PR DESCRIPTION
The iterator shouldn't return "January 1, year+1" for non-leap years with `BYYEARDAY=366`. Nor should it return "December 31, year-1" for `BYYEARDAY=-366`. I've changed `next_year` to work more like `next_month` and return 0 if there are no matches in the year.