### PR TITLE
fix: typing of VCardTime.icaltype

### DIFF
--- a/lib/ical/vcard_time.js
+++ b/lib/ical/vcard_time.js
@@ -83,7 +83,7 @@ class VCardTime extends Time {
    */
   constructor(data, zone, icaltype) {
     super(data, zone);
-    this.icaltype = icaltype || "date-and-or-time";
+    this._icaltype = icaltype || "date-and-or-time";
   }
 
   /**
@@ -99,7 +99,9 @@ class VCardTime extends Time {
    * @type {String}
    * @default "date-and-or-time"
    */
-  icaltype = "date-and-or-time";
+  get icaltype() {
+    return this._icaltype;
+  }
 
   /**
    * Returns a clone of the vcard date/time object.


### PR DESCRIPTION
Fix #916 

Caveat: `icaltype` will not be settable anymore. But I think that this is the correct behavior anyway.