### PR TITLE
Fix event iterator start time clamping

### DIFF
--- a/lib/ical/event.js
+++ b/lib/ical/event.js
@@ -283,9 +283,15 @@ class Event {
    * @return {RecurExpansion}    Expansion object
    */
   iterator(startTime) {
+    let dtstart = this.startDate;
+
+    if (startTime && dtstart && startTime.compare(dtstart) > 0) {
+      dtstart = startTime;
+    }
+
     return new RecurExpansion({
       component: this.component,
-      dtstart: startTime || this.startDate
+      dtstart
     });
   }
 

--- a/test/event_test.js
+++ b/test/event_test.js
@@ -801,16 +801,29 @@ suite('ICAL.Event', function() {
   });
 
   suite('#iterator', function() {
-    test('with start time', function() {
+    test('with later start time', function() {
       let start = subject.startDate;
       let time = new ICAL.Time({
-        day: start.da + 1,
+        day: start.day + 1,
         month: start.month,
         year: start.year
       });
 
       let iterator = subject.iterator(time);
       assert.deepEqual(iterator.last.toString(), time.toString());
+      assert.instanceOf(iterator, ICAL.RecurExpansion);
+    });
+
+    test('with earlier start time', function() {
+      let start = subject.startDate;
+      let time = new ICAL.Time({
+        day: start.day - 1,
+        month: start.month,
+        year: start.year
+      });
+
+      let iterator = subject.iterator(time);
+      assert.deepEqual(iterator.last.toString(), subject.startDate.toString());
       assert.instanceOf(iterator, ICAL.RecurExpansion);
     });
 


### PR DESCRIPTION
## Summary

- Clamp `Event#iterator(startTime)` so an earlier caller-provided start time cannot move recurrence expansion before the event `DTSTART`.
- Keep later `startTime` behavior intact.
- Repair the existing iterator test typo and add earlier-start regression coverage.

Fixes #456.

## Verification

- `PATH=/opt/homebrew/bin:$PATH npm run test-unit -- test/event_test.js` (62 passing in no-space verification clone)
- `PATH=/opt/homebrew/bin:$PATH npm run lint`
- `PATH=/opt/homebrew/bin:$PATH npm run test` (1021 passing, 1 pending, plus 5 acceptance tests in no-space verification clone)
- `git diff --check`

Note: the original local checkout path contains a space, which trips the existing test helper's `URL.pathname` handling before Mocha tests run. I verified the exact same diff in a temporary no-space clone.

## AI assistance

Prepared with AI assistance and manually verified before submission.