### PR TITLE
fix: skip non-existent Feb 29 instances for yearly recurrence (RFC 5545 3.3.10)

### DIFF
--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -1107,8 +1107,15 @@ class RecurIterator {
 
     if (partCount == 0) {
       let t1 = this.dtstart.clone();
+      let month = t1.month, day = t1.day;
       t1.year = this.last.year;
-      this.days.push(t1.dayOfYear());
+      // Setting the year may roll a February 29th anchor over to March 1st in
+      // a non-leap year. That instance does not exist, so per RFC 5545 3.3.10
+      // it must be ignored. Leaving this.days empty lets the surrounding loops
+      // advance to the next year.
+      if (t1.month == month && t1.day == day) {
+        this.days.push(t1.dayOfYear());
+      }
     } else if (partCount == 1 && "BYMONTH" in parts) {
       for (let month of this.by_data.BYMONTH) {
         let t2 = this.dtstart.clone();

--- a/test/recur_iterator_test.js
+++ b/test/recur_iterator_test.js
@@ -1590,13 +1590,12 @@ suite('recur_iterator', function() {
       /*
        * Leap-year test for February 29th
        *
-       * See https://github.com/kewisch/ical.js/issues/91
-       * for details
+       * A bare yearly rule anchored on February 29th must recur only in leap
+       * years; non-leap years have no February 29th and per RFC 5545 3.3.10
+       * those invalid instances MUST be ignored (not rolled over to March 1st).
        *
-       * TODO: Uncomment when new recurrence iterator is ready
+       * See https://github.com/kewisch/ical.js/issues/91 for details.
        */
-
-      /*
       testRRULE('FREQ=YEARLY;', {
         dtStart: '2012-02-29T12:00:00',
         dates: [
@@ -1604,7 +1603,6 @@ suite('recur_iterator', function() {
           '2016-02-29T12:00:00'
         ]
       });
-      */
 
       // Multiple BYYEARDAYs, checks that we start on the right one.
       testRRULE('FREQ=YEARLY;BYYEARDAY=73,146,219,292', {


### PR DESCRIPTION
## Problem

A bare `FREQ=YEARLY` rule anchored on February 29th emits March 1st instances in non-leap years instead of recurring in leap years only.

With `DTSTART:2012-02-29T12:00:00` and `RRULE:FREQ=YEARLY`:

| # | Before (HEAD) | After (this PR) |
|---|---|---|
| 1 | 2012-02-29 | 2012-02-29 |
| 2 | **2013-03-01** | 2016-02-29 |
| 3 | **2014-03-01** | 2020-02-29 |
| 4 | **2015-03-01** | 2024-02-29 |
| 5 | 2016-02-29 | 2028-02-29 |

The three March 1st rows do not exist in the recurrence set, and they also throw off `COUNT`. python-dateutil yields the leap-years-only sequence (2012, 2016, 2020, ...).

## Spec

RFC 5545 section 3.3.10:

> Recurrence rules may generate recurrence instances with an invalid date (e.g., February 30) ... Such recurrence instances MUST be ignored and MUST NOT be counted as part of the recurrence set.

February 29th in a non-leap year is exactly such an invalid date, so a Feb 29 yearly rule has no instance in those years and must skip them.

## Root cause

In `RecurIterator#expand_year_days`, the bare-frequency (`partCount == 0`) branch clones the Feb 29 anchor and sets `year` to the current year. `Time`'s setter normalizes the invalid date, silently rewriting Feb 29 to Mar 1 in non-leap years. `this.days` is therefore never empty, so the existing year-skipping loop (which the surrounding code already relies on for impossible yearly rules) never advances past the non-leap year and the rolled-over Mar 1 is yielded.

## Fix

Record the anchor month/day before setting the year, then only push the day-of-year if the date did not drift. When it drifted (Feb 29 became Mar 1), `this.days` stays empty and the existing loops advance to the next year, as RFC 5545 requires. Both call sites of `expand_year_days` already handle an empty `this.days`.

A normal yearly rule (e.g. anchored Jan 15) and a genuine Mar 1 anchor are unchanged, since their dates do not drift when the year is set. The MONTHLY day-31 path is a separate branch and is untouched.

## Tests

This completes the fix deferred in #91 and enables the test that was merged commented out (`test/recur_iterator_test.js`). The test fails on the current HEAD (yields 2013-03-01 as the second instance) and passes with this change.

Full unit and acceptance suites are green.