### PR TITLE
Fix vCard 3 time value to keep ':' separators on serialization

### DIFF
--- a/lib/ical/design.js
+++ b/lib/ical/design.js
@@ -834,7 +834,13 @@ let vcard3Values = extend(commonValues, {
   "phone-number": vcardValues["phone-number"],
   uri: icalValues.uri,
   text: vcardValues.text,
-  time: icalValues.time,
+  time: {
+    // As in vCard, but serialised differently (':' are included).
+    ...vcardValues.time,
+    toICAL: function(aValue) {
+      return aValue;
+    }
+  },
   vcard: icalValues.text,
   "utc-offset": {
     toICAL: function(aValue) {

--- a/test/design_test.js
+++ b/test/design_test.js
@@ -579,6 +579,31 @@ suite('design', function() {
       });
     });
 
+    suite('time (vcard3)', function() {
+      setup(function() {
+        subject = ICAL.design.vcard3.value.time;
+      });
+
+      test('#(to|from)ICAL time', function() {
+        let original = '15:00:00';
+        let fromICAL = subject.fromICAL(original);
+
+        assert.equal(fromICAL, '15:00:00');
+        assert.equal(subject.toICAL(fromICAL), original);
+      });
+
+      test('#(un)decorate time', function() {
+        let undecorated = '15:00:00';
+        let decorated = subject.decorate(undecorated);
+
+        assert.equal(decorated.hour, 15, 'hour');
+        assert.equal(decorated.minute, 0, 'minute');
+        assert.equal(decorated.second, 0, 'second');
+
+        assert.equal(subject.undecorate(decorated), undecorated);
+      });
+    });
+
     suite('duration', function() {
       setup(function() {
         subject = subject.value.duration;


### PR DESCRIPTION
#962 fixed the vCard 3 `date` and `date-time` value types to serialize with their separators (`-` and `:`), because vCard 3 uses the ISO 8601 extended form (e.g. `REV:1995-10-31T22:27:10Z`). The third member of that group, the standalone `time` value, was left pointing at `icalValues.time`, which strips the colons and assumes the basic `HHMMSS` form.

That breaks both directions for a vCard 3 time:

```js
ICAL.design.vcard3.value.time.fromICAL('15:30:00'); // '15::3:0:'  (mangled)
```

End to end, a property with `VALUE=time` round-trips to a corrupted value:

```
BEGIN:VCARD
VERSION:3.0
FN:Test
X-TIME;VALUE=time:15:30:00
END:VCARD
```

parses and re-serializes as `X-TIME;VALUE=TIME:15:30:` (seconds dropped, colons mangled). Note the time portion of a vCard 3 `date-time` already keeps its colons (`2026-02-24T15:30:00`), so the standalone `time` value was inconsistent with it.

The fix applies the same shape #962 used for `date`/`date-time`: reuse `vcardValues.time` for parsing and decoration, and override `toICAL` to keep the value as-is. With that, `15:30:00`, `15:30:00Z` and `15:30:00-05:00` all round-trip, and the value decorates to a proper `VCardTime`.

Added a `time (vcard3)` suite next to the existing `date (vcard3)` / `date-time (vcard3)` suites. `npm run test` and `npm run lint` pass.
