### PR TITLE
Fix isDate true->false not clearing hour/minute/second (#501)

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -550,6 +550,14 @@ class Time {
     // what normalize will do when time is a date.
     if (attr === "isDate" && val && !this._time.isDate) {
       this.adjust(0, 0, 0, 0);
+      // Zero the time fields eagerly. Normalization is lazy and only clears
+      // hour/minute/second while isDate is true (see _normalize). Flipping
+      // isDate true->false before _normalize() runs would make that guard
+      // false, so the time fields would never be cleared (see #501). adjust()
+      // must run first to preserve the days-not-lost behavior from #263.
+      this._time.hour = 0;
+      this._time.minute = 0;
+      this._time.second = 0;
     }
     this._cachedUnixTime = null;
     this._pendingNormalization = true;

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -157,6 +157,42 @@ suite('icaltime', function() {
 
   });
 
+  suite('#501 - flipping isDate true then false clears the time', function() {
+    test('hour/minute/second are cleared', function() {
+      let time = new ICAL.Time({
+        second: 56,
+        minute: 34,
+        hour: 12,
+        day: 1,
+        month: 1,
+        year: 2022
+      });
+
+      time.isDate = true;
+      time.isDate = false;
+
+      assert.equal(time.hour, 0);
+      assert.equal(time.minute, 0);
+      assert.equal(time.second, 0);
+    });
+
+    test('adjust still runs first so days are not lost', function() {
+      let time = new ICAL.Time({
+        hour: 14,
+        day: 10,
+        month: 8,
+        year: 2016
+      });
+
+      time.adjust(1, 10, 0, 0);
+      time.isDate = true;
+
+      assert.equal(time.year, 2016);
+      assert.equal(time.month, 8);
+      assert.equal(time.day, 12);
+    });
+  });
+
   suite('#subtractDate and #subtractDateTz', function() {
     testSupport.useTimezones('America/Los_Angeles', 'America/New_York');
 


### PR DESCRIPTION
Fixes #501

## Problem
Setting `.isDate = true` then `.isDate = false` should clear hour/minute/second, but the time fields survive:

```js
const t = new ICAL.Time({ second: 56, minute: 34, hour: 12, day: 1, month: 1, year: 2022 });
t.isDate = true;
t.isDate = false;
// t.hour === 12, t.minute === 34, t.second === 56  (expected 0, 0, 0)
```

## Root cause
`Time._setTimeAttr` handles the `isDate = true` transition by calling `adjust(0, 0, 0, 0)` and then deferring the actual clearing via `_pendingNormalization = true`. The clearing itself lives only in `_normalize()`, guarded by `if (this._time.isDate)`. Because normalization is lazy, flipping `isDate` back to `false` before `_normalize()` runs makes that guard false, so hour/minute/second are never zeroed.

## Fix
Zero hour/minute/second eagerly on the `isDate = true` transition, right after `adjust(0, 0, 0, 0)`. `adjust()` still runs first, so the days-not-lost behavior from #263 is preserved (e.g. `2016-08-10T14:00` + `adjust(1,10,0,0)` still lands on `2016-08-12` when converted to a date).

## Testing
- Added a `#501` test asserting h/m/s are cleared after the true->false flip, plus a regression test that days are not lost.
- Red/green verified: without the fix the new test fails with `expected 12 to equal +0`; with the fix it passes.
- Full suite: 1022 passing, 0 failing; eslint clean.

---
This contribution was prepared with AI assistance.