### PR TITLE
Flush pending normalization in Time#clone(); fixes #1024

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -562,6 +562,10 @@ class Time {
    * @return {Time}              The cloned object
    */
   clone() {
+    if (this._pendingNormalization) {
+      this._normalize();
+      this._pendingNormalization = false;
+    }
     return new Time(this._time, this.zone);
   }
 

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -157,6 +157,32 @@ suite('icaltime', function() {
 
   });
 
+  suite('#clone', function() {
+    function pendingNormalizationDate() {
+      let subject = new ICAL.Time({ year: 2025, month: 1, day: 11, isDate: true });
+      // Adding a sub-day duration to a date is a no-op, but it leaves the
+      // normalization pending.
+      subject.addDuration(ICAL.Duration.fromString('-PT8H'));
+      return subject;
+    }
+
+    test('date with pending normalization', function() {
+      assert.equal(pendingNormalizationDate().clone().toString(), '2025-01-11');
+    });
+
+    test('date normalized by a read before cloning', function() {
+      let subject = pendingNormalizationDate();
+      assert.equal(subject.toString(), '2025-01-11');
+      assert.equal(subject.clone().toString(), '2025-01-11');
+    });
+
+    test('date-time with pending normalization', function() {
+      let subject = new ICAL.Time({ year: 2025, month: 1, day: 11, hour: 4 });
+      subject.addDuration(ICAL.Duration.fromString('-PT8H'));
+      assert.equal(subject.clone().toString(), '2025-01-10T20:00:00');
+    });
+  });
+
   suite('#subtractDate and #subtractDateTz', function() {
     testSupport.useTimezones('America/Los_Angeles', 'America/New_York');
 


### PR DESCRIPTION
ICAL.Time normalizes lazily, but clone() hands the raw _time to the constructor. fromData() then applies a pending out-of-range hour while isDate is still false, and the trailing isDate = true adjusts it into the day - so cloning a DATE with a pending sub-day duration moved it back a day, while reading the source first did not.